### PR TITLE
feat: create follow and unfollow endpoints

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,0 +1,95 @@
+# Profile 
+
+## Follow User
+
+### Endpoint: `POST` `/api/profile/:username/follow`
+
+### Authentication required
+```JSON
+{
+  "Authorization": "Bearer jwt.token.here"
+}
+```
+### Params:
+
+| Name | Type |
+|:-----|:-----|
+| `username` *required*| `String` |
+
+### Response Body Type:
+| Name | Type |
+|:-----|:-----|
+| `profile` | `Object` |
+| `username` | `String` |
+| `bio` | `String or null` |
+| `image` | `String or null` |
+| `following` | `Boolean` |
+
+### Response Body Example:
+```JSON 
+{
+     "user": {
+         "username": "example",    
+         "bio": "I love examples",
+         "image": null,
+         "following": true
+     }
+} 
+```
+### Errors:
+> #### `StatusCode` `400` - Invalid request body
+>
+> Must provide required params content listed above
+> #### `StatusCode` `404` - Invalid request body
+>
+> Username provided in params does not exist
+> #### `StatusCode` `422` - Payload value(s) not unqiue
+>
+> The current user already follows the requested profile 
+
+## Unfollow User
+
+### Endpoint: `DELETE` `/api/profile/:username/follow`
+
+### Authentication required
+```JSON
+{
+  "Authorization": "Bearer jwt.token.here"
+}
+```
+### Params:
+
+| Name | Type |
+|:-----|:-----|
+| `username` *required*| `String` |
+
+### Response Body Type:
+| Name | Type |
+|:-----|:-----|
+| `profile` | `Object` |
+| `username` | `String` |
+| `bio` | `String or null` |
+| `image` | `String or null` |
+| `following` | `Boolean` |
+
+### Response Body Example:
+```JSON 
+{
+     "user": {
+         "username": "example",    
+         "bio": "I love examples",
+         "image": null,
+         "following": false
+     }
+} 
+```
+### Errors:
+> #### `StatusCode` `400` - Invalid request body
+>
+> Must provide required body content listed above 
+> #### `StatusCode` `404` - Invalid request body
+>
+> Username provided in params does not exist
+> #### `StatusCode` `422` - Payload value(s) not unqiue
+>
+> The current user already follows the requested profile 

--- a/docs/users.md
+++ b/docs/users.md
@@ -4,7 +4,7 @@
 
 ### Endpoint: `POST` `/api/users`
 
-### Authentication header not requred
+### Authentication header not required
 
 ### Request Body Type:
 
@@ -61,7 +61,7 @@
 
 ### Endpoint: `POST` `/api/users/login`
 
-### Authentication header not requred
+### Authentication header not required
 
 ### Request Body Type:
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -117,7 +117,7 @@ module.exports = {
   // resolver: undefined,
 
   // Automatically restore mock state and implementation before every test
-  // restoreMocks: false,
+  restoreMocks: true,
 
   // The root directory that Jest should scan for tests and modules within
   // rootDir: undefined,

--- a/src/controllers/profiles.js
+++ b/src/controllers/profiles.js
@@ -1,0 +1,68 @@
+import { queryOneUser } from "../utils/userControllerUtils";
+import {
+  profilePayloadFormat,
+  followProfile,
+  unfollowProfile,
+} from "../utils/profileControllerUtils";
+import { errorHandles } from "../utils/errorHandleUtils";
+
+export async function handleFollowProfile(req, res) {
+  try {
+    if (req.user.username === req.params.username) {
+      throw new Error("query and current user cannot be the same");
+    }
+    const currentUser = req.user;
+    const followingUser = await queryOneUser({ username: req.params.username });
+    if (!followingUser) { throw new Error("user query does not exist");
+    }
+    const isFollowing = await followProfile(
+      currentUser.email,
+      followingUser.email
+    );
+
+    const profilePayload = profilePayloadFormat(followingUser, isFollowing);
+
+    res.status(201).json(profilePayload);
+  } catch (e) {
+    console.error(e);
+
+    const error = errorHandles.find(({ message }) => message === e.message);
+
+    if (!error) return res.status(500).send("Server Error");
+
+    return res.status(error.statusCode).send(error.message);
+  }
+}
+
+export async function handleUnfollowProfile(req, res) {
+  try {
+    if (req.user.username === req.params.username) {
+      throw new Error("query and current user cannot be the same");
+    }
+    const currentUser = req.user;
+    const followingUser = await queryOneUser({
+      username: req.params.username,
+    });
+
+    if (!followingUser) {
+      throw new Error("user query does not exist");
+    }
+
+    const isFollowing = await unfollowProfile(
+      currentUser.email,
+      followingUser.email
+    );
+
+    const profilePayload = profilePayloadFormat(followingUser, isFollowing);
+
+    res.status(200).json(profilePayload);
+  } catch (e) {
+    console.error(e);
+
+    const error = errorHandles.find(({ message }) => message === e.message);
+
+    if (!error) return res.status(500).send("Server Error");
+
+    return res.status(error.statusCode).send(error.message);
+  }
+}

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -5,7 +5,6 @@ import {
   queryOneUser,
   queryOneUserAndUpdate,
   userPayloadFormat,
-  getToken
 } from "../utils/userControllerUtils";
 import { signToken } from "../utils/jwtUtils";
 import { errorHandles } from "../utils/errorHandleUtils";
@@ -42,6 +41,7 @@ export async function registerUser(req, res) {
   } catch (e) {
     console.error(e);
 
+
     const error = errorHandles.find(({ message }) => message === e.message);
 
     if (!error) return res.status(500).send("Server Error");
@@ -51,7 +51,7 @@ export async function registerUser(req, res) {
 }
 
 export async function getUser(req, res) {
-  const user = await queryOneUser(req.user.email);
+  const user = await queryOneUser({ email: req.user.email });
 
   const token = signToken(user, "1w");
 
@@ -74,7 +74,7 @@ export async function loginUser(req, res) {
       throw new Error("Invalid payload format");
     }
 
-    const foundUser = await queryOneUser(user.email);
+    const foundUser = await queryOneUser({ email: user.email });
 
     const match = await verifyPassword(user, foundUser);
 
@@ -104,13 +104,15 @@ export async function updateUser(req, res) {
     if (!user) {
       throw new Error("No payload found");
     }
-    const formattedUser = updateUserInputFormat(user)
+    const formattedUser = updateUserInputFormat(user);
     if (!formattedUser) {
       throw new Error("Invalid payload format");
     }
 
-
-    const updatedUser = await queryOneUserAndUpdate(req.user.email, formattedUser);
+    const updatedUser = await queryOneUserAndUpdate(
+      req.user.email,
+      formattedUser
+    );
 
     const token = signToken(updatedUser, "1w");
 

--- a/src/models/follows.js
+++ b/src/models/follows.js
@@ -17,14 +17,14 @@ const FollowModel = sequelize.define("Follow", {
       model: UserModel,
       key: "email",
     },
-    followingId: {
-      type: DataTypes.STRING,
-      allownull: false,
-      unique: true,
-      references: {
-        model: UserModel,
-        key: "email",
-      },
+  },
+  followingId: {
+    type: DataTypes.STRING,
+    allownull: false,
+    unique: true,
+    references: {
+      model: UserModel,
+      key: "email",
     },
   },
 });
@@ -33,13 +33,13 @@ UserModel.belongsToMany(UserModel, {
   through: "Follow",
   foreignKey: "userId",
   as: "followers",
-  onDelete: "CASCADE"
+  onDelete: "CASCADE",
 });
 UserModel.belongsToMany(UserModel, {
   through: "Follow",
   foreignKey: "followingId",
   as: "following",
-  onDelete: "CASCADE"
+  onDelete: "CASCADE",
 });
 
 export default FollowModel;

--- a/src/models/follows.js
+++ b/src/models/follows.js
@@ -1,0 +1,45 @@
+import { DataTypes } from "sequelize-cockroachdb";
+import sequelize from "./index";
+import UserModel from "./users";
+
+const FollowModel = sequelize.define("Follow", {
+  id: {
+    type: DataTypes.UUID,
+    unique: true,
+    primaryKey: true,
+    allownull: false,
+    defaultValue: DataTypes.UUIDV4,
+  },
+  userId: {
+    type: DataTypes.STRING,
+    allownull: false,
+    references: {
+      model: UserModel,
+      key: "email",
+    },
+    followingId: {
+      type: DataTypes.STRING,
+      allownull: false,
+      unique: true,
+      references: {
+        model: UserModel,
+        key: "email",
+      },
+    },
+  },
+});
+
+UserModel.belongsToMany(UserModel, {
+  through: "Follow",
+  foreignKey: "userId",
+  as: "followers",
+  onDelete: "CASCADE"
+});
+UserModel.belongsToMany(UserModel, {
+  through: "Follow",
+  foreignKey: "followingId",
+  as: "following",
+  onDelete: "CASCADE"
+});
+
+export default FollowModel;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,8 +1,10 @@
 import { Router } from "express";
 const router = Router();
 import userRoute from './users'
+import profileRoute from './profiles'
 
 router.use('/users', userRoute)
+router.use('/profiles', profileRoute)
 
 export default router;
 

--- a/src/routes/profiles.js
+++ b/src/routes/profiles.js
@@ -1,0 +1,9 @@
+import { Router } from "express";
+const router = Router();
+import { deserializeUser } from "../middleware/deserializeUser";
+import { handleFollowProfile, handleUnfollowProfile } from "../controllers/profiles"
+
+router.post("/:username/follow", deserializeUser, handleFollowProfile);
+router.delete("/:username/follow", deserializeUser, handleUnfollowProfile);
+
+export default router;

--- a/src/utils/errorHandleUtils.js
+++ b/src/utils/errorHandleUtils.js
@@ -28,6 +28,14 @@ export const errorHandles = [
     message: "Payload value(s) not unique",
     statusCode: 422
   },
+  {
+    message: "query and current user cannot be the same",
+    statusCode: 400
+  },
+  {
+    message: "user query does not exist",
+    statusCode: 404
+  },
 ]
 export const jwtErrorHandles = [
   {

--- a/src/utils/profileControllerUtils.js
+++ b/src/utils/profileControllerUtils.js
@@ -1,0 +1,46 @@
+import FollowModel from "../models/follows";
+
+export async function followProfile(userEmail, followingUserEmail) {
+  try {
+    await FollowModel.create({
+      userId: userEmail,
+      followingId: followingUserEmail,
+    });
+    return true;
+  } catch (e) {
+    console.error(e);
+    if (e.name === "SequelizeUniqueContraintError") {
+      throw new Error("Payload value(s) not unique");
+    }
+    return null;
+  }
+}
+
+export async function unfollowProfile(userEmail, unfollowUserEmail) {
+  try {
+    const destroy = await FollowModel.destroy({
+      where: {
+        userId: userEmail,
+        followingId: unfollowUserEmail,
+      },
+    });
+    if (destroy === 0) {
+      throw new Error("No user unfollowed");
+    }
+    return false;
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
+}
+
+export function profilePayloadFormat(followingUser, isFollowing) {
+  return {
+    profile: {
+      username: followingUser.username,
+      bio: followingUser.bio,
+      image: followingUser.image,
+      following: isFollowing,
+    },
+  };
+}

--- a/src/utils/userControllerUtils.js
+++ b/src/utils/userControllerUtils.js
@@ -18,9 +18,9 @@ export async function createUser(user) {
   }
 }
 
-export async function queryOneUser(email) {
+export async function queryOneUser(payload) {
   try {
-    const user = await UserModel.findOne({ where: { email: email } });
+    const user = await UserModel.findOne({ where: payload });
     const { createdAt, updatedAt, ...userPayload } = user.get();
     return userPayload;
   } catch (e) {

--- a/test/end-to-end/profiles.test.js
+++ b/test/end-to-end/profiles.test.js
@@ -1,0 +1,570 @@
+import * as userControllerUtils from "../../src/utils/userControllerUtils";
+import * as profileControllerUtils from "../../src/utils/profileControllerUtils";
+import * as jwtUtils from "../../src/utils/jwtUtils";
+import supertest from "supertest";
+import createServer from "../../src/utils/serverSetup";
+import { profileDbPayload, profileResponse } from "../utils/profilesTestValue";
+import { verifyTokenPayload, dbPayload } from "../utils/testValues";
+import { deserializeUser } from "../../src/middleware/deserializeUser";
+
+const app = createServer();
+
+describe("test profile routes", () => {
+  describe("POST /api/profiles/:username/follow", () => {
+    describe("Given the username to follow exists and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 201 and profile payload", async () => {
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        const queryUserMock = jest
+          .spyOn(userControllerUtils, "queryOneUser")
+          .mockReturnValueOnce(profileDbPayload);
+
+        const followUserMock = jest
+          .spyOn(profileControllerUtils, "followProfile")
+          .mockReturnValueOnce(true);
+
+        const { body, statusCode } = await supertest(app)
+          .post("/api/profiles/tester/follow")
+          .set("Authorization", `Bearer ${token}`);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(201);
+
+        expect(body).toEqual(profileResponse(true));
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryUserMock).toHaveBeenCalledWith({
+          username: "tester",
+        });
+
+        expect(followUserMock).toHaveBeenCalledWith(
+          verifyTokenPayload.email,
+          profileDbPayload.email
+        );
+      });
+    });
+    describe("Given the username to follow does not exist and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 404", async () => {
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        const queryUserMock = jest
+          .spyOn(userControllerUtils, "queryOneUser")
+          .mockReturnValueOnce(null);
+
+        const followUserMock = jest.spyOn(
+          profileControllerUtils,
+          "unfollowProfile"
+        );
+
+        const { statusCode } = await supertest(app)
+          .post("/api/profiles/tester/follow")
+          .set("Authorization", `Bearer ${token}`);
+
+        expect(statusCode).toBe(404);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryUserMock).toHaveBeenCalledWith({
+          username: expect.any(String),
+        });
+
+        expect(followUserMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Given the username to follow is the same as current user and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 400", async () => {
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        const queryUserMock = jest
+          .spyOn(userControllerUtils, "queryOneUser")
+          .mockReturnValueOnce(null);
+
+        const followUserMock = jest.spyOn(
+          profileControllerUtils,
+          "followProfile"
+        );
+
+        const { statusCode } = await supertest(app)
+          .post("/api/profiles/newtwo/follow")
+          .set("Authorization", `Bearer ${token}`);
+
+        expect(statusCode).toBe(400);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryUserMock).not.toHaveBeenCalled();
+
+        expect(followUserMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Authorization header not provided", () => {
+      it("should return 403 and redirect to '/'", async () => {
+        const mockReq = {
+          get: jest.fn(() => null),
+        };
+        const mockRes = {
+          redirect: jest.fn(),
+        };
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest.spyOn(jwtUtils, "verifyToken");
+
+        const queryUserMock = jest.spyOn(
+          userControllerUtils,
+          "queryOneUserAndUpdate"
+        );
+
+        const response = await supertest(app).post(
+          "/api/profiles/tester/follow"
+        );
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(response.statusCode).toBe(403);
+        expect(response.headers.location).toEqual("/");
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockNext).not.toHaveBeenCalled();
+        expect(mockRes.redirect).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).not.toHaveBeenCalled();
+
+        expect(queryUserMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("given invalid jwt token payload format", () => {
+      it("should return 403 and redirect to '/'", async () => {
+        const mockReq = {
+          get: jest.fn(() => "Bearer fake.token"),
+        };
+        const mockRes = {
+          redirect: jest.fn(),
+        };
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest.spyOn(jwtUtils, "verifyToken");
+
+        const queryUserAndUpdateMock = jest.spyOn(
+          userControllerUtils,
+          "queryOneUserAndUpdate"
+        );
+
+        const response = await supertest(app)
+          .post("/api/profiles/tester/follow")
+          .set("Authorization", "Bearer fake.token");
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(response.statusCode).toBe(403);
+        expect(response.headers.location).toEqual("/");
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith("Authorization");
+        expect(mockNext).not.toHaveBeenCalled();
+        expect(mockRes.redirect).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toThrow();
+
+        expect(queryUserAndUpdateMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Given the username to follow is already followed and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 400", async () => {
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        const queryUserMock = jest
+          .spyOn(userControllerUtils, "queryOneUser")
+          .mockReturnValueOnce(profileDbPayload);
+
+        const followUserMock = jest
+          .spyOn(profileControllerUtils, "followProfile")
+          .mockRejectedValueOnce(new Error("Payload value(s) not unique"));
+
+        const { statusCode } = await supertest(app)
+          .post("/api/profiles/tester/follow")
+          .set("Authorization", `Bearer ${token}`);
+
+        expect(statusCode).toBe(422);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryUserMock).toHaveBeenCalledWith({
+          username: "tester",
+        });
+
+        expect(followUserMock).toHaveBeenCalled()
+      });
+    });
+    describe("given expired jwt token", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "-1h")));
+      it("should return 403 and redirect to '/'", async () => {
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {
+          redirect: jest.fn(),
+        };
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest.spyOn(jwtUtils, "verifyToken");
+
+        const queryUserAndUpdateMock = jest.spyOn(
+          userControllerUtils,
+          "queryOneUserAndUpdate"
+        );
+
+        const response = await supertest(app)
+          .post("/api/profiles/tester/follow")
+          .set("Authorization", `Bearer ${token}`);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(response.statusCode).toBe(403);
+        expect(response.headers.location).toEqual("/");
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith("Authorization");
+        expect(mockNext).not.toHaveBeenCalled();
+        expect(mockRes.redirect).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toThrow();
+
+        expect(queryUserAndUpdateMock).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("DELETE /api/profiles/:username/follow", () => {
+    describe("Given the username to unfollow exists and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 200 and profile payload", async () => {
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        const queryUserMock = jest
+          .spyOn(userControllerUtils, "queryOneUser")
+          .mockReturnValueOnce(profileDbPayload);
+
+        const unfollowUserMock = jest
+          .spyOn(profileControllerUtils, "unfollowProfile")
+          .mockReturnValueOnce(false);
+
+        const { body, statusCode } = await supertest(app)
+          .delete("/api/profiles/tester/follow")
+          .set("Authorization", `Bearer ${token}`);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(200);
+
+        expect(body).toEqual(profileResponse(false));
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryUserMock).toHaveBeenCalledWith({
+          username: "tester",
+        });
+
+        expect(unfollowUserMock).toHaveBeenCalledWith(
+          verifyTokenPayload.email,
+          profileDbPayload.email
+        );
+      });
+    });
+
+    describe("Given the username to unfollow does not exist and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 404", async () => {
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        const queryUserMock = jest
+          .spyOn(userControllerUtils, "queryOneUser")
+          .mockReturnValueOnce(null);
+
+        const unfollowUserMock = jest.spyOn(
+          profileControllerUtils,
+          "unfollowProfile"
+        );
+
+        const { statusCode } = await supertest(app)
+          .delete("/api/profiles/pokemon/follow")
+          .set("Authorization", `Bearer ${token}`);
+
+        expect(statusCode).toBe(404);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryUserMock).toHaveBeenCalledWith({
+          username: "pokemon",
+        });
+
+        expect(unfollowUserMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Given the username to unfollow is the same as current user and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 400", async () => {
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        const queryUserMock = jest
+          .spyOn(userControllerUtils, "queryOneUser")
+          .mockReturnValueOnce(null);
+
+        const unfollowUserMock = jest.spyOn(
+          profileControllerUtils,
+          "unfollowProfile"
+        );
+
+        const { statusCode } = await supertest(app)
+          .delete("/api/profiles/newtwo/follow")
+          .set("Authorization", `Bearer ${token}`);
+
+        expect(statusCode).toBe(400);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryUserMock).not.toHaveBeenCalled();
+
+        expect(unfollowUserMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Authorization header not provided", () => {
+      it("should return 403 and redirect to '/'", async () => {
+        const mockReq = {
+          get: jest.fn(() => null),
+        };
+        const mockRes = {
+          redirect: jest.fn(),
+        };
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest.spyOn(jwtUtils, "verifyToken");
+
+        const queryUserMock = jest.spyOn(
+          userControllerUtils,
+          "queryOneUserAndUpdate"
+        );
+
+        const response = await supertest(app).delete(
+          "/api/profiles/tester/follow"
+        );
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(response.statusCode).toBe(403);
+        expect(response.headers.location).toEqual("/");
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockNext).not.toHaveBeenCalled();
+        expect(mockRes.redirect).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).not.toHaveBeenCalled();
+
+        expect(queryUserMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("given invalid jwt token payload format", () => {
+      it("should return 403 and redirect to '/'", async () => {
+        const mockReq = {
+          get: jest.fn(() => "Bearer fake.token"),
+        };
+        const mockRes = {
+          redirect: jest.fn(),
+        };
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest.spyOn(jwtUtils, "verifyToken");
+
+        const queryUserAndUpdateMock = jest.spyOn(
+          userControllerUtils,
+          "queryOneUserAndUpdate"
+        );
+
+        const response = await supertest(app)
+          .delete("/api/profiles/tester/follow")
+          .set("Authorization", "Bearer fake.token");
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(response.statusCode).toBe(403);
+        expect(response.headers.location).toEqual("/");
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith("Authorization");
+        expect(mockNext).not.toHaveBeenCalled();
+        expect(mockRes.redirect).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toThrow();
+
+        expect(queryUserAndUpdateMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("given expired jwt token", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "-1h")));
+      it("should return 403 and redirect to '/'", async () => {
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {
+          redirect: jest.fn(),
+        };
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest.spyOn(jwtUtils, "verifyToken");
+
+        const queryUserAndUpdateMock = jest.spyOn(
+          userControllerUtils,
+          "queryOneUserAndUpdate"
+        );
+
+        const response = await supertest(app)
+          .delete("/api/profiles/tester/follow")
+          .set("Authorization", `Bearer ${token}`);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(response.statusCode).toBe(403);
+        expect(response.headers.location).toEqual("/");
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith("Authorization");
+        expect(mockNext).not.toHaveBeenCalled();
+        expect(mockRes.redirect).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toThrow();
+
+        expect(queryUserAndUpdateMock).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/test/end-to-end/users.test.js
+++ b/test/end-to-end/users.test.js
@@ -158,7 +158,9 @@ describe("test user routes", () => {
 
         expect(statusCode).toBe(200);
 
-        expect(queryUserMock).toHaveBeenCalledWith(userLoginInput.user.email);
+        expect(queryUserMock).toHaveBeenCalledWith({
+          email: userLoginInput.user.email,
+        });
 
         expect(verifyPasswordMock).toHaveBeenCalledWith(
           userLoginInput.user,
@@ -228,9 +230,9 @@ describe("test user routes", () => {
 
         expect(statusCode).toBe(401);
 
-        expect(queryUserMock).toHaveBeenCalledWith(
-          invalidLoginPassword.user.email
-        );
+        expect(queryUserMock).toHaveBeenCalledWith({
+          email: invalidLoginPassword.user.email,
+        });
 
         expect(verifyPasswordMock).toHaveBeenCalledWith(
           invalidLoginPassword.user,
@@ -256,9 +258,9 @@ describe("test user routes", () => {
 
         expect(statusCode).toBe(401);
 
-        expect(queryUserMock).toHaveBeenCalledWith(
-          invalidLoginEmail.user.email
-        );
+        expect(queryUserMock).toHaveBeenCalledWith({
+          email: invalidLoginEmail.user.email,
+        });
 
         expect(verifyPasswordMock).toHaveBeenCalledWith(
           invalidLoginEmail.user,
@@ -308,7 +310,9 @@ describe("test user routes", () => {
 
         expect(verifyTokenMock).toHaveBeenCalledWith(token);
 
-        expect(queryUserMock).toHaveBeenCalledWith(verifyTokenPayload.email);
+        expect(queryUserMock).toHaveBeenCalledWith({
+          email: verifyTokenPayload.email,
+        });
       });
     });
     describe("Authorization header not provided", () => {
@@ -465,7 +469,10 @@ describe("test user routes", () => {
           { bio: updateUserInput.user.bio }
         );
 
-        expect(signTokenMock).toHaveBeenCalledWith({...dbPayload, bio: updateUserInput.user.bio}, "1w");
+        expect(signTokenMock).toHaveBeenCalledWith(
+          { ...dbPayload, bio: updateUserInput.user.bio },
+          "1w"
+        );
       });
     });
     describe("given user payload the username value is not unique and authentication is valid", () => {
@@ -493,7 +500,6 @@ describe("test user routes", () => {
 
         await deserializeUser(mockReq, mockRes, mockNext);
 
-        console.log(body);
         expect(statusCode).toBe(422);
 
         // middleware tests

--- a/test/integration/profileControllerUtils.test.js
+++ b/test/integration/profileControllerUtils.test.js
@@ -1,0 +1,91 @@
+import { createUser } from "../../src/utils/userControllerUtils";
+import {
+  followProfile,
+  unfollowProfile,
+} from "../../src/utils/profileControllerUtils";
+import UserModel from "../../src/models/users";
+
+const user = {
+  email: "user@user.user",
+  username: "follower",
+  hash: "(Salt)y(Hash)browns",
+};
+const createFollowing = {
+  email: "follw@follow.follow",
+  username: "following",
+  hash: "(Salt)y(Hash)browns",
+};
+describe("Integration tests for profile controller utils", () => {
+  beforeAll(async () => {
+    await createUser(createFollowing);
+    await createUser(user);
+  });
+  afterAll(async () => {
+    await UserModel.destroy({ where: {
+      email: user.email
+    } });
+    await UserModel.destroy({ where: {
+      email: createFollowing.email
+    } });
+  });
+  describe("Test functionality of followProfile()", () => {
+    describe("Given query user exists to follow user", () => {
+      it("should return true", async () => {
+        const isFollowing = await followProfile(
+          user.email,
+          createFollowing.email
+        );
+
+        expect(isFollowing).toBe(true);
+      });
+    });
+    describe("Given query user is not unique", () => {
+      it("should cause FollowModel to throw error", async () => {
+        try {
+          await followProfile(user.email, createFollowing.email);
+        } catch (e) {
+          expect(e.message).toEqual("SequelizeUniqueConstraintError");
+        }
+      });
+    });
+    describe("Given query user doesnt exist", () => {
+      it("should return null", async () => {
+        const isFollowing = await followProfile(user.email, "wont@work.okay");
+
+        expect(isFollowing).toBeNull();
+      });
+    });
+  });
+
+  describe("Test functionality of unfollowProfile()", () => {
+    describe("Given query user exists to unfollow user", () => {
+      it("should return false", async () => {
+        const isFollowing = await unfollowProfile(
+          user.email,
+          createFollowing.email
+        );
+
+        expect(isFollowing).toBe(false);
+      });
+    });
+    describe("Given query user is not unique", () => {
+      it("should throw error", async () => {
+        try {
+          await unfollowProfile(createUser.email, createFollowing.email);
+        } catch (e) {
+          expect(followProfile).toThrow();
+          expect(e.message).toEqual("Payload value(s) not unique");
+        }
+      });
+    });
+    describe("Given query user doesnt exist", () => {
+      it("should return null", async () => {
+        const isFollowing = await unfollowProfile(user.email, 
+          "wont@work.atAll",
+        );
+
+        expect(isFollowing).toBeNull();
+      });
+    });
+  });
+});

--- a/test/integration/userControllerUtils.test.js
+++ b/test/integration/userControllerUtils.test.js
@@ -24,8 +24,6 @@ describe("Integration tests for user controller utils", () => {
     await UserModel.destroy({
       where: { email: "test@test.test" },
     });
-  });
-  afterAll(async () => {
     await UserModel.destroy({
       where: {
         email: createUserInput.user.email,
@@ -46,8 +44,6 @@ describe("Integration tests for user controller utils", () => {
         try {
           const hash = dbPayload.hash;
           const user = await createUser({ ...createUserInput.user, hash });
-
-          expect(user).toThrow();
         } catch (e) {
           expect(e.message).toEqual("Payload value(s) not unique");
         }
@@ -66,14 +62,16 @@ describe("Integration tests for user controller utils", () => {
   describe("Test functionality of queryOneUser()", () => {
     describe("Given valid email that is already stored in the db", () => {
       it("should return corresponding email db payload", async () => {
-        const user = await queryOneUser(createUserInput.user.email);
+        const user = await queryOneUser({ email: createUserInput.user.email });
 
         expect(user).toEqual(dbPayload);
       });
     });
     describe("Given valid email that is not stored in the db", () => {
       it("should cause UserModel to throw error and return null ", async () => {
-        const user = await queryOneUser(invalidLoginEmail.user.email);
+        const user = await queryOneUser({
+          email: invalidLoginEmail.user.email,
+        });
 
         expect(UserModel).toThrow();
         expect(user).toBeNull();

--- a/test/utils/profilesTestValue.js
+++ b/test/utils/profilesTestValue.js
@@ -1,0 +1,17 @@
+export const profileDbPayload = {
+  email: "test@test.test",
+  username: "tester",
+  bio: null,
+  image: null,
+};
+
+export function profileResponse(isFollowing) {
+  return {
+    profile: {
+      username: expect.toBeOneOf([null,expect.any(String)]),
+      bio: expect.toBeOneOf([null, expect.any(String)]),
+      image: expect.toBeOneOf([null, expect.any(String)]),
+      following: isFollowing,
+    },
+  };
+}


### PR DESCRIPTION
# Summary
In this PR I set up profile routes and controllers to handle the profile endpoints. I first created a Follow schema to store a many-to-many relationship between the author (which is the current user) and the following user to be joined to the Follow table. I can use this table to track which current user and other profiles are following. The route uses authentication middleware (`deserializeUser`) and `followUser` / `unfollowUser` controllers to handle follow/unfollow process. The controllers queries the database with the username provided. If the user exists, the current user and requested profile to follow will be inserted into a row in the Follow table. Then return the response data. The unfollow process is similar but instead of inserting a row, it destroys the requested row.

# Screenshots of tests
![Screenshot 2022-10-18 at 6 25 19 PM](https://user-images.githubusercontent.com/60503218/196568981-49f8297a-6e6d-48b3-b59d-de836c2d1008.png)
![Screenshot 2022-10-18 at 6 25 34 PM](https://user-images.githubusercontent.com/60503218/196568990-8f229e63-b989-49b2-9aac-4af2362a1837.png)
![Screenshot 2022-10-18 at 6 25 44 PM](https://user-images.githubusercontent.com/60503218/196568997-c0b3f88a-18d8-452d-a645-b891eb446900.png)
