### PR TITLE
feat: create get profile endpoint

### DIFF
--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -1,6 +1,6 @@
 # Profile 
 
-## Follow User
+## Follow Profile
 
 ### Endpoint: `POST` `/api/profile/:username/follow`
 
@@ -47,7 +47,7 @@
 >
 > The current user already follows the requested profile 
 
-## Unfollow User
+## Unfollow Profile
 
 ### Endpoint: `DELETE` `/api/profile/:username/follow`
 
@@ -86,7 +86,54 @@
 ### Errors:
 > #### `StatusCode` `400` - Invalid request body
 >
-> Must provide required body content listed above 
+> Must provide required params content listed above
+> #### `StatusCode` `404` - Invalid request body
+>
+> Username provided in params does not exist
+> #### `StatusCode` `422` - Payload value(s) not unqiue
+>
+> The current user already follows the requested profile 
+
+## Get Profile Data 
+
+### Endpoint: `GET` `/api/profile/:username`
+
+### Authentication required
+```JSON
+{
+  "Authorization": "Bearer jwt.token.here"
+}
+```
+### Params:
+
+| Name | Type |
+|:-----|:-----|
+| `username` *required*| `String` |
+
+### Response Body Type:
+| Name | Type |
+|:-----|:-----|
+| `profile` | `Object` |
+| `username` | `String` |
+| `bio` | `String or null` |
+| `image` | `String or null` |
+| `following` | `Boolean` |
+
+### Response Body Example:
+```JSON 
+{
+     "user": {
+         "username": "example",    
+         "bio": "I love examples",
+         "image": null,
+         "following": false
+     }
+} 
+```
+### Errors:
+> #### `StatusCode` `400` - Invalid request body
+>
+> Must provide required params content listed above
 > #### `StatusCode` `404` - Invalid request body
 >
 > Username provided in params does not exist

--- a/docs/users.md
+++ b/docs/users.md
@@ -215,7 +215,6 @@
      }
 } 
 ```
-// TODO: add errors for non unique username and email
 ### Errors:
 > #### `StatusCode` `400` - Invalid request body
 >

--- a/src/controllers/profiles.js
+++ b/src/controllers/profiles.js
@@ -3,6 +3,7 @@ import {
   profilePayloadFormat,
   followProfile,
   unfollowProfile,
+  isFollowing
 } from "../utils/profileControllerUtils";
 import { errorHandles } from "../utils/errorHandleUtils";
 
@@ -13,7 +14,8 @@ export async function handleFollowProfile(req, res) {
     }
     const currentUser = req.user;
     const followingUser = await queryOneUser({ username: req.params.username });
-    if (!followingUser) { throw new Error("user query does not exist");
+    if (!followingUser) {
+      throw new Error("user query does not exist");
     }
     const isFollowing = await followProfile(
       currentUser.email,
@@ -22,7 +24,7 @@ export async function handleFollowProfile(req, res) {
 
     const profilePayload = profilePayloadFormat(followingUser, isFollowing);
 
-    res.status(201).json(profilePayload);
+    return res.status(201).json(profilePayload);
   } catch (e) {
     console.error(e);
 
@@ -55,7 +57,36 @@ export async function handleUnfollowProfile(req, res) {
 
     const profilePayload = profilePayloadFormat(followingUser, isFollowing);
 
-    res.status(200).json(profilePayload);
+    return res.status(200).json(profilePayload);
+  } catch (e) {
+    console.error(e);
+
+    const error = errorHandles.find(({ message }) => message === e.message);
+
+    if (!error) return res.status(500).send("Server Error");
+
+    return res.status(error.statusCode).send(error.message);
+  }
+}
+
+export async function handleGetProfile(req, res) {
+  try {
+    const profileUser = await queryOneUser({ username: req.params.username });
+    if(!profileUser){
+      throw new Error("user query does not exist")
+    }
+
+    const isFollowingProfile = await isFollowing(
+      req.user.email,
+      profileUser.email
+    );
+
+    const profilePayload = profilePayloadFormat(
+      profileUser,
+      isFollowingProfile
+    );
+
+    return res.status(200).json(profilePayload);
   } catch (e) {
     console.error(e);
 

--- a/src/routes/profiles.js
+++ b/src/routes/profiles.js
@@ -1,9 +1,14 @@
 import { Router } from "express";
 const router = Router();
 import { deserializeUser } from "../middleware/deserializeUser";
-import { handleFollowProfile, handleUnfollowProfile } from "../controllers/profiles"
+import {
+  handleFollowProfile,
+  handleGetProfile,
+  handleUnfollowProfile,
+} from "../controllers/profiles";
 
 router.post("/:username/follow", deserializeUser, handleFollowProfile);
 router.delete("/:username/follow", deserializeUser, handleUnfollowProfile);
+router.get("/:username", deserializeUser, handleGetProfile);
 
 export default router;

--- a/src/utils/profileControllerUtils.js
+++ b/src/utils/profileControllerUtils.js
@@ -34,6 +34,15 @@ export async function unfollowProfile(userEmail, unfollowUserEmail) {
   }
 }
 
+export async function isFollowing(userEmail, profileEmail) {
+  const check = await FollowModel.findOne({
+    where: {
+      userId: userEmail,
+      followingId: profileEmail,
+    },
+  });
+  return !!check;
+}
 export function profilePayloadFormat(followingUser, isFollowing) {
   return {
     profile: {

--- a/test/end-to-end/users.test.js
+++ b/test/end-to-end/users.test.js
@@ -493,7 +493,7 @@ describe("test user routes", () => {
           .spyOn(userControllerUtils, "queryOneUserAndUpdate")
           .mockRejectedValueOnce(new Error("Payload value(s) not unique"));
 
-        const { statusCode, body } = await supertest(app)
+        const { statusCode } = await supertest(app)
           .put("/api/users")
           .set("Authorization", `Bearer ${token}`)
           .send({ user: { username: "takenUsername" } });

--- a/test/integration/profileControllerUtils.test.js
+++ b/test/integration/profileControllerUtils.test.js
@@ -2,6 +2,7 @@ import { createUser } from "../../src/utils/userControllerUtils";
 import {
   followProfile,
   unfollowProfile,
+  isFollowing
 } from "../../src/utils/profileControllerUtils";
 import UserModel from "../../src/models/users";
 
@@ -21,12 +22,16 @@ describe("Integration tests for profile controller utils", () => {
     await createUser(user);
   });
   afterAll(async () => {
-    await UserModel.destroy({ where: {
-      email: user.email
-    } });
-    await UserModel.destroy({ where: {
-      email: createFollowing.email
-    } });
+    await UserModel.destroy({
+      where: {
+        email: user.email
+      }
+    });
+    await UserModel.destroy({
+      where: {
+        email: createFollowing.email
+      }
+    });
   });
   describe("Test functionality of followProfile()", () => {
     describe("Given query user exists to follow user", () => {
@@ -80,11 +85,37 @@ describe("Integration tests for profile controller utils", () => {
     });
     describe("Given query user doesnt exist", () => {
       it("should return null", async () => {
-        const isFollowing = await unfollowProfile(user.email, 
+        const isFollowing = await unfollowProfile(user.email,
           "wont@work.atAll",
         );
 
         expect(isFollowing).toBeNull();
+      });
+    });
+  });
+
+  // TODO: create test user/profile for this test
+  describe("Test functionality of isFollowing()", () => {
+    beforeAll(async () => await followProfile(user.email, createFollowing.email))
+    describe("Given current user follows query user", () => {
+      it("should return true", async () => {
+        const isFollowingProfile = await isFollowing(
+          user.email,
+          createFollowing.email
+        );
+
+        expect(isFollowingProfile).toBe(true);
+      });
+    });
+    describe("Given current user does not follow query user", () => {
+      beforeAll(async () => await unfollowProfile(user.email, createFollowing.email))
+      it("should return false", async () => {
+        const isFollowingProfile = await isFollowing(
+          user.email,
+          createFollowing.email
+        );
+
+        expect(isFollowingProfile).toBe(false);
       });
     });
   });


### PR DESCRIPTION
# Summary
In this PR, I created the get profile endpoint. This endpoint has a controller and a middleware which requires the user to be authenticated. The controller checks if the username exists by querying the db. If the user exists, the data will be used to check if the profile is followed by the current user and then formatted to the profile response format.

# Screenshots of the tests
<img width="598" alt="Screenshot 2022-10-19 at 7 30 17 AM" src="https://user-images.githubusercontent.com/60503218/196686178-a0795e7d-c4b1-4a32-bf67-cddeb60d73e2.png">
<img width="627" alt="Screenshot 2022-10-19 at 7 30 56 AM" src="https://user-images.githubusercontent.com/60503218/196686103-b5f6a13d-8fc6-4342-8c40-3467cc9ccaba.png">
<img width="602" alt="Screenshot 2022-10-19 at 7 31 21 AM" src="https://user-images.githubusercontent.com/60503218/196686141-6f9e26ff-665e-45c0-87c9-33a7499c9236.png">
<img width="534" alt="Screenshot 2022-10-19 at 7 31 37 AM" src="https://user-images.githubusercontent.com/60503218/196686223-200ab651-24b1-43bf-b004-2f39f1c5a1de.png">
<img width="689" alt="Screenshot 2022-10-19 at 7 31 47 AM" src="https://user-images.githubusercontent.com/60503218/196686250-dfddcd42-f3f5-409b-a11f-64aeed79f2e1.png">

