### PR TITLE
feat: create POST /api/articles endpoint

### DIFF
--- a/docs/articles.md
+++ b/docs/articles.md
@@ -1,0 +1,81 @@
+# Articles 
+
+## Create Article
+
+### Endpoint: `POST` `/api/articles`
+
+### Authentication header required
+
+ Authentication header Type: 
+| Name | Type |
+|:-----|:-----|
+| `Authorization` | `String` |
+
+### Authentication header example: 
+```JSON
+{
+  "Authorization": "Bearer jwt.token.here"
+}
+```
+
+### Request Body Type:
+
+| Name | Type |
+|:-----|:-----|
+| `article` *required* | `Object` |
+| `title` *required*| `String` |
+| `description` *required*| `String` |
+| `body` *required*| `String` |
+| `tagList` | `Array or null` |
+
+### Request Body Example:
+```JSON 
+{
+     "user": {
+         "username": "example",    
+         "email": "example@example.example",
+         "password": "1exampleword"
+     }
+} 
+```
+### Response Body Type:
+| Name | Type |
+|:-----|:-----|
+| `article` | `Object` |
+| `title` | `String` |
+| `description` | `String` |
+| `body` | `String` |
+| `tagList` | `Array or undefined` |
+
+### Response Body Example:
+```JSON 
+{
+     "article": {
+         "title": "example",    
+         "description": "This is an example",    
+         "body": "I love examples",
+         "tagList": ["example", "new"],
+     }
+} 
+```
+```JSON 
+{
+     "article": {
+         "title": "example",    
+         "description": "This is an example",    
+         "body": "I love examples",
+     }
+} 
+```
+### Errors:
+> #### `StatusCode` `400` - Invalid request body
+>
+> Must provide required body content listed above or invalid email type provided
+> #### `StatusCode` `422` - Payload value(s) not unqiue
+>
+> The requested email or username creation is already taken by another user 
+> #### `StatusCode` `403` - Unauthorized
+>
+> This error will redirect user to homepage. 
+>
+> Authorization header not provided, Expired JWT token, Invalid JWT token

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -5,6 +5,13 @@
 ### Endpoint: `POST` `/api/profile/:username/follow`
 
 ### Authentication required
+
+ Authentication header Type: 
+| Name | Type |
+|:-----|:-----|
+| `Authorization` | `String` |
+
+### Authentication header example: 
 ```JSON
 {
   "Authorization": "Bearer jwt.token.here"
@@ -46,12 +53,24 @@
 > #### `StatusCode` `422` - Payload value(s) not unqiue
 >
 > The current user already follows the requested profile 
+> #### `StatusCode` `403` - Unauthorized
+>
+> This error will redirect user to homepage. 
+>
+> Authorization header not provided, Expired JWT token, Invalid JWT token
 
 ## Unfollow Profile
 
 ### Endpoint: `DELETE` `/api/profile/:username/follow`
 
 ### Authentication required
+
+ Authentication header Type: 
+| Name | Type |
+|:-----|:-----|
+| `Authorization` | `String` |
+
+### Authentication header example: 
 ```JSON
 {
   "Authorization": "Bearer jwt.token.here"
@@ -93,12 +112,24 @@
 > #### `StatusCode` `422` - Payload value(s) not unqiue
 >
 > The current user already follows the requested profile 
+> #### `StatusCode` `403` - Unauthorized
+>
+> This error will redirect user to homepage. 
+>
+> Authorization header not provided, Expired JWT token, Invalid JWT token
 
 ## Get Profile Data 
 
 ### Endpoint: `GET` `/api/profile/:username`
 
 ### Authentication required
+
+ Authentication header Type: 
+| Name | Type |
+|:-----|:-----|
+| `Authorization` | `String` |
+
+### Authentication header example: 
 ```JSON
 {
   "Authorization": "Bearer jwt.token.here"
@@ -140,3 +171,8 @@
 > #### `StatusCode` `422` - Payload value(s) not unqiue
 >
 > The current user already follows the requested profile 
+> #### `StatusCode` `403` - Unauthorized
+>
+> This error will redirect user to homepage. 
+>
+> Authorization header not provided, Expired JWT token, Invalid JWT token

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:e2e": "jest test/end-to-end --verbose",
     "test": "jest . --verbose",
     "test:async": "jest . --runInBand --detectOpenHandles --coverage --verbose",
-    "test:silent": "jest . --runInBand --detectOpenHandles --silent --coverage --verbose"
+    "test:silent": "jest . --runInBand --detectOpenHandles --silent --coverage --verbose",
+    "test:screenshot": "jest . --runInBand --detectOpenHandles --silent --coverage"
   },
   "repository": {
     "type": "git",

--- a/src/controllers/articles.js
+++ b/src/controllers/articles.js
@@ -1,0 +1,41 @@
+import { validateBody } from "../utils/validators";
+import {
+  createArticle,
+  articlePayloadFormat,
+} from "../utils/articleControllerUtils";
+import { errorHandles } from "../utils/errorHandleUtils";
+
+export async function handleCreateArticle(req, res) {
+  try {
+    const { article } = req.body;
+    const expectedPayload = {
+      title: "string",
+      description: "string",
+      body: "string",
+      tagList: "object null",
+    };
+    if (!article) {
+      throw new Error("No payload found");
+    }
+    if (!validateBody(article, expectedPayload)) {
+      throw new Error("Invalid payload format"); 
+    }
+    if (!!article.tagList && !Array.isArray(article.tagList)) {
+      throw new Error("Invalid payload format"); // test this
+    }
+
+    const newArticle = await createArticle(req.user.email, article);
+
+    const articlePayload = articlePayloadFormat(newArticle);
+
+    return res.status(201).json(articlePayload);
+  } catch (e) {
+    console.error(e);
+
+    const error = errorHandles.find(({ message }) => message === e.message);
+
+    if (!error) return res.status(500).send("Server Error");
+
+    return res.status(error.statusCode).send(error.message);
+  }
+}

--- a/src/models/articles.js
+++ b/src/models/articles.js
@@ -1,0 +1,27 @@
+import { DataTypes } from "sequelize-cockroachdb";
+import sequelize from "./index";
+
+const ArticleModel = sequelize.define("Article", {
+  id: {
+    type: DataTypes.UUID,
+    unique: true,
+    primaryKey: true,
+    allowNull: false,
+    defaultValue: DataTypes.UUIDV4
+  },
+  title: {
+    type: DataTypes.STRING,
+    unique: true,
+    allownull: false,
+  },
+  description: {
+    type: DataTypes.STRING,
+    allownull: false,
+  },
+  body: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+});
+
+export default ArticleModel;

--- a/src/models/articles.js
+++ b/src/models/articles.js
@@ -1,5 +1,6 @@
 import { DataTypes } from "sequelize-cockroachdb";
 import sequelize from "./index";
+import UserModel from "./users";
 
 const ArticleModel = sequelize.define("Article", {
   id: {
@@ -7,7 +8,15 @@ const ArticleModel = sequelize.define("Article", {
     unique: true,
     primaryKey: true,
     allowNull: false,
-    defaultValue: DataTypes.UUIDV4
+    defaultValue: DataTypes.UUIDV4,
+  },
+  authorId: {
+    type: DataTypes.STRING,
+    allowNull: null,
+    references: {
+      model: UserModel,
+      key: "email",
+    },
   },
   title: {
     type: DataTypes.STRING,
@@ -22,6 +31,12 @@ const ArticleModel = sequelize.define("Article", {
     type: DataTypes.STRING,
     allowNull: false,
   },
+});
+
+UserModel.hasMany(ArticleModel, {
+  foreignKey: "authorId",
+  as: "articles",
+  onDelete: "CASCADE",
 });
 
 export default ArticleModel;

--- a/src/models/tags.js
+++ b/src/models/tags.js
@@ -1,6 +1,6 @@
 import { DataTypes } from "sequelize-cockroachdb";
 import sequelize from "./index";
-import ArticleModel from "./aticles"
+import ArticleModel from "./articles";
 
 const TagModel = sequelize.define("Tag", {
   id: {
@@ -8,19 +8,25 @@ const TagModel = sequelize.define("Tag", {
     unique: true,
     primaryKey: true,
     allownull: false,
-    defaultValue: DataTypes.UUIDV4
+    defaultValue: DataTypes.UUIDV4,
   },
   articleId: {
-    type: DataTypes.STRING,
-    unique: true,
+    type: DataTypes.UUID,
     allownull: false,
+    references: {
+      model: ArticleModel,
+      key: "id",
+    },
   },
   tag: {
-    type: DataTypes.STRING
-  }
+    type: DataTypes.STRING,
+  },
 });
 
-ArticleModel.hasMany(TagModel, { foreignKey: "articleId", as: "tags"})
-TagModel.belongsTo(ArticleModel)
+ArticleModel.hasMany(TagModel, {
+  foreignKey: "articleId",
+  as: "tags",
+  onDelete: "CASCADE",
+});
 
 export default TagModel;

--- a/src/models/tags.js
+++ b/src/models/tags.js
@@ -1,0 +1,26 @@
+import { DataTypes } from "sequelize-cockroachdb";
+import sequelize from "./index";
+import ArticleModel from "./aticles"
+
+const TagModel = sequelize.define("Tag", {
+  id: {
+    type: DataTypes.UUID,
+    unique: true,
+    primaryKey: true,
+    allownull: false,
+    defaultValue: DataTypes.UUIDV4
+  },
+  articleId: {
+    type: DataTypes.STRING,
+    unique: true,
+    allownull: false,
+  },
+  tag: {
+    type: DataTypes.STRING
+  }
+});
+
+ArticleModel.hasMany(TagModel, { foreignKey: "articleId", as: "tags"})
+TagModel.belongsTo(ArticleModel)
+
+export default TagModel;

--- a/src/routes/articles.js
+++ b/src/routes/articles.js
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { deserializeUser } from "../middleware/deserializeUser";
+import { handleCreateArticle } from "../controllers/articles";
+
+const router = Router();
+
+router.post("/", deserializeUser, handleCreateArticle);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,10 +1,11 @@
 import { Router } from "express";
 const router = Router();
-import userRoute from './users'
-import profileRoute from './profiles'
+import userRoute from "./users";
+import profileRoute from "./profiles";
+import articleRoute from "./articles";
 
-router.use('/users', userRoute)
-router.use('/profiles', profileRoute)
+router.use("/users", userRoute);
+router.use("/profiles", profileRoute);
+router.use("/articles", articleRoute);
 
 export default router;
-

--- a/src/utils/articleControllerUtils.js
+++ b/src/utils/articleControllerUtils.js
@@ -1,0 +1,43 @@
+import ArticleModel from "../models/articles";
+import TagModel from "../models/tags";
+import { validateTagList } from "../utils/validators";
+
+export async function createArticle(userEmail, article) {
+  try {
+    const newArticle = await ArticleModel.create({
+      authorId: userEmail,
+      title: article.title,
+      description: article.description,
+      body: article.body,
+    });
+    const { createdAt, updatedAt, authorId, id, ...newArticlePayload } =
+      newArticle.get();
+    if (validateTagList(article.tagList)) {
+      const dbTag = article.tagList.map((tag) => {
+        return {
+          articleId: newArticle.id,
+          tag: tag,
+        };
+      });
+      const tagListDb = await TagModel.bulkCreate(dbTag);
+      newArticlePayload.tagList = tagListDb.map(tagList => tagList.tag)
+    }
+    return newArticlePayload;
+  } catch (e) {
+    console.error(e);
+    if (e.name === "SequelizeUniqueContraintError") {
+      throw new Error("Payload value(s) not unique");
+    }
+    return null;
+  }
+}
+export function articlePayloadFormat(article) {
+  return {
+    article: {
+      title: article.title,
+      description: article.description,
+      body: article.body,
+      tagList: article.tagList,
+    },
+  };
+}

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -31,3 +31,12 @@ export function validateEmail(email) {
   const regex = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/
   return regex.test(email)
 }
+
+export function validateTagList(tags){
+  if(!tags || tags.length === 0){
+    return false
+  }
+  const isValid = tags.some( tag => typeof(tag) === "string" ) 
+  return isValid
+}
+

--- a/test/end-to-end/articles.test.js
+++ b/test/end-to-end/articles.test.js
@@ -1,0 +1,232 @@
+import supertest from "supertest";
+import createServer from "../../src/utils/serverSetup"
+import {
+  articleDbPayload,
+  expectArticlePayload,
+  articlePayload,
+  invalidArticlePayloadFormat,
+  invalidTaglistPayload
+} from "../utils/articlesTestValue";
+import { verifyTokenPayload, dbPayload } from "../utils/testValues"
+import { deserializeUser } from "../../src/middleware/deserializeUser";
+import * as jwtUtils from "../../src/utils/jwtUtils"
+import * as articleControllerUtils from "../../src/utils/articleControllerUtils"
+
+const app = createServer();
+
+describe("test article route", () => {
+  describe("POST /api/articles - Article creation", () => {
+    describe("Given request payload is valid and current user is authenticated", () => {
+      let token = ""
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 201 and article payload", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const createArticleMock = jest
+          .spyOn(articleControllerUtils, "createArticle")
+          .mockReturnValueOnce(articleDbPayload);
+
+        const { body, statusCode } = await supertest(app)
+          .post("/api/articles")
+          .set("Authorization", `Bearer ${token}`)
+          .send(articlePayload)
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(201);
+
+        expect(body).toEqual(expectArticlePayload);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(createArticleMock).toHaveBeenCalledWith(
+          verifyTokenPayload.email,
+          articleDbPayload
+        );
+      });
+    });
+    describe("Given request payload is empty and current user is authenticated", () => {
+      let token =""
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 400", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const createArticleMock = jest
+          .spyOn(articleControllerUtils, "createArticle")
+          .mockReturnValueOnce(articleDbPayload);
+
+        const { statusCode } = await supertest(app)
+          .post("/api/articles")
+          .set("Authorization", `Bearer ${token}`);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(400);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(createArticleMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Given invalid payload format", () => {
+      let token =""
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 400", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const createArticleMock = jest
+          .spyOn(articleControllerUtils, "createArticle")
+
+        const { statusCode } = await supertest(app)
+          .post("/api/articles")
+          .set("Authorization", `Bearer ${token}`)
+          .send(invalidArticlePayloadFormat)
+          
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(400);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(createArticleMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Given valid payload, but tagList type is invalid", () => {
+      let token = ""
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 400", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const createArticleMock = jest
+          .spyOn(articleControllerUtils, "createArticle")
+          .mockReturnValueOnce(articleDbPayload);
+
+        const { statusCode } = await supertest(app)
+          .post("/api/articles")
+          .set("Authorization", `Bearer ${token}`)
+          .send(invalidTaglistPayload)
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(400);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(createArticleMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Given request payload is not unique, and current user is authenticated", () => {
+      let token = ""
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 422", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const createArticleMock = jest
+          .spyOn(articleControllerUtils, "createArticle")
+          .mockRejectedValueOnce(new Error("Payload value(s) not unique"));
+
+        const { statusCode } = await supertest(app)
+          .post("/api/articles")
+          .set("Authorization", `Bearer ${token}`)
+          .send(articlePayload)
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(422);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(createArticleMock).toHaveBeenCalledWith(
+          verifyTokenPayload.email,
+          articleDbPayload
+        );
+      });
+    });
+  });
+});

--- a/test/end-to-end/profiles.test.js
+++ b/test/end-to-end/profiles.test.js
@@ -12,7 +12,7 @@ const app = createServer();
 describe("test profile routes", () => {
   // Following User Test
   
-  describe("POST /api/profiles/:username/follow", () => {
+  describe("POST /api/profiles/:username/follow - Follow profile", () => {
     describe("Given the username to follow exists and current user is authenticated", () => {
       let token = "";
       beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
@@ -314,7 +314,7 @@ describe("test profile routes", () => {
   });
 
   // Unfollowing User Test
-  describe("DELETE /api/profiles/:username/follow", () => {
+  describe("DELETE /api/profiles/:username/follow - Unfollowing profile", () => {
     describe("Given the username to unfollow exists and current user is authenticated", () => {
       let token = "";
       beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
@@ -571,7 +571,7 @@ describe("test profile routes", () => {
     });
   });
   // GET Profile Tests
-  describe("GET /api/profiles/:username", () => {
+  describe("GET /api/profiles/:username - Get profile data", () => {
     describe("Given the username to exist and current user is authenticated", () => {
       let token = "";
       beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));

--- a/test/integration/articleControllerUtils.test.js
+++ b/test/integration/articleControllerUtils.test.js
@@ -1,0 +1,63 @@
+import {
+  articleDbPayload,
+  expectArticlePayload,
+} from "../utils/articlesTestValue";
+import { createArticle } from "../../src/utils/articleControllerUtils";
+import { createUser } from "../../src/utils/userControllerUtils";
+import UserModel from "../../src/models/users";
+
+const user = {
+  email: "person@person.person",
+  username: "person",
+  hash: "(Salt)y(Hash)browns",
+};
+describe("Integration tests for profile controller utils", () => {
+  beforeAll(async () => {
+    await createUser(user);
+  });
+  afterAll(async () => {
+    await UserModel.destroy({
+      where: {
+        email: user.email,
+      },
+    });
+  });
+  describe("Test functionality of createArticle()", () => {
+    describe("Given body payload with tag list is valid", () => {
+      it("should return article db payload", async () => {
+        const newArticle = await createArticle(user.email, articleDbPayload);
+        expect(newArticle).toEqual(expectArticlePayload.article);
+      });
+    });
+    describe("Given valid body payload without tagList", () => {
+      it("should return article db payload", async () => {
+        const { tagList, ...articleDbPayloadCase2 } = articleDbPayload;
+        const newArticle = await createArticle(user.email, {
+          ...articleDbPayloadCase2,
+          title: "new article",
+        });
+        expect(newArticle).toEqual(expectArticlePayload.article);
+      });
+    });
+    describe("Given valid body payload with invalid tagList", () => {
+      it("should return article db payload", async () => {
+        const { tagList, ...articleDbPayloadCase2 } = expectArticlePayload.article;
+        const newArticle = await createArticle(user.email, {
+          ...articleDbPayload,
+          title: "newer article",
+          tagList: [null, 13, [], {}],
+        });
+        expect(newArticle).toEqual(articleDbPayloadCase2);
+      });
+    });
+    describe("Given body payload that is not unique ", () => {
+      it("should return null", async () => {
+        try {
+          await createArticle(user.email, articleDbPayload);
+        } catch (e) {
+          expect(e.message).toEqual("Payload value(s) not unique");
+        }
+      });
+    });
+  });
+});

--- a/test/utils/articlesTestValue.js
+++ b/test/utils/articlesTestValue.js
@@ -1,0 +1,32 @@
+export const articleDbPayload = {
+  title: "Click bait here",
+  description: "real and true",
+  body: "Life hacks",
+  tagList: ["new", "hacks"],
+};
+export const articlePayload = {
+  article: {
+    ...articleDbPayload,
+  },
+};
+export const invalidArticlePayloadFormat = {
+  article: {
+    bio: "wrong",
+    name: "wrong still",
+  },
+};
+export const invalidTaglistPayload = {
+  article: {
+    ...articleDbPayload,
+    tagList: {},
+  },
+};
+
+export const expectArticlePayload = {
+  article: {
+    title: expect.any(String),
+    description: expect.any(String),
+    body: expect.any(String),
+    tagList: expect.toBeOneOf([undefined, null, expect.any(Array)]),
+  },
+};


### PR DESCRIPTION
# Summary
In this PR I set the articles route in order to create the POST endpoint for /api/articles. This route uses authentication middleware. The controller validates the payload before it is processed to be created in the database. I created an `ArticleModel` schema to store the `title`, `description`, `body` and `TagModel` schema to store the `tagList` from the payload. Note that `TagModel` association to `ArticleModel` is a one-to-many relation and `ArticleModel` association to `UserModel` is also one-to-many. The `createArticle()` function pushes the data into the database using the `ArticleModel` and the `TagModel`.  Then the payload is formatted and sent back to the requester.

# ScreenShots of the tests
<img width="481" alt="Screenshot 2022-10-20 at 11 34 56 AM" src="https://user-images.githubusercontent.com/60503218/196999217-feb2a6fb-9660-400a-8a60-d793e20c026e.png">
<img width="730" alt="Screenshot 2022-10-20 at 11 35 16 AM" src="https://user-images.githubusercontent.com/60503218/196999258-ab6fc7dc-1670-4055-b77a-bb7055b1a8c8.png">
