### PR TITLE
feat: create GET /api/articles/:slug endpoint

### DIFF
--- a/src/controllers/profiles.js
+++ b/src/controllers/profiles.js
@@ -15,7 +15,7 @@ export async function handleFollowProfile(req, res) {
     const currentUser = req.user;
     const followingUser = await queryOneUser({ username: req.params.username });
     if (!followingUser) {
-      throw new Error("user query does not exist");
+      throw new Error("query does not exist");
     }
     const isFollowing = await followProfile(
       currentUser.email,
@@ -47,7 +47,7 @@ export async function handleUnfollowProfile(req, res) {
     });
 
     if (!followingUser) {
-      throw new Error("user query does not exist");
+      throw new Error("query does not exist");
     }
 
     const isFollowing = await unfollowProfile(
@@ -73,7 +73,7 @@ export async function handleGetProfile(req, res) {
   try {
     const profileUser = await queryOneUser({ username: req.params.username });
     if(!profileUser){
-      throw new Error("user query does not exist")
+      throw new Error("query does not exist")
     }
 
     const isFollowingProfile = await isFollowing(

--- a/src/models/articles.js
+++ b/src/models/articles.js
@@ -21,11 +21,16 @@ const ArticleModel = sequelize.define("Article", {
   title: {
     type: DataTypes.STRING,
     unique: true,
-    allownull: false,
+    allowNull: false,
+  },
+  slug: {
+    type: DataTypes.STRING,
+    unique: true,
+    allowNull: false,
   },
   description: {
     type: DataTypes.STRING,
-    allownull: false,
+    allowNull: false,
   },
   body: {
     type: DataTypes.STRING,
@@ -35,8 +40,9 @@ const ArticleModel = sequelize.define("Article", {
 
 UserModel.hasMany(ArticleModel, {
   foreignKey: "authorId",
-  as: "articles",
+  as: "author",
   onDelete: "CASCADE",
 });
+ArticleModel.belongsTo(UserModel, {foreignKey: "authorId", onDelete: "CASCADE", as:"author"})
 
 export default ArticleModel;

--- a/src/models/favorties.js
+++ b/src/models/favorties.js
@@ -1,0 +1,45 @@
+import { DataTypes } from "sequelize-cockroachdb";
+import sequelize from "./index";
+import ArticleModel from "./articles";
+import UserModel from "./users";
+
+const FavoriteModel = sequelize.define("Favorite", {
+  id: {
+    type: DataTypes.UUID,
+    unique: true,
+    primaryKey: true,
+    allownull: false,
+    defaultValue: DataTypes.UUIDV4,
+  },
+  articleId: {
+    type: DataTypes.UUID,
+    allownull: false,
+    references: {
+      model: ArticleModel,
+      key: "id",
+    },
+  },
+  userId: {
+    type: DataTypes.STRING,
+    allownull: false,
+    references: {
+      model: UserModel,
+      key: "email",
+    },
+  },
+});
+
+UserModel.belongsToMany(ArticleModel, {
+  through: "Favorite",
+  as: "isFavorite",
+  foreignKey: "userId",
+  onDelete: "CASCADE",
+});
+ArticleModel.belongsToMany(UserModel, {
+  through: "Favorite",
+  as: "favoritesCount",
+  foreignKey: "articleId",
+  onDelete: "CASCADE",
+});
+
+export default FavoriteModel;

--- a/src/models/follows.js
+++ b/src/models/follows.js
@@ -32,7 +32,7 @@ const FollowModel = sequelize.define("Follow", {
 UserModel.belongsToMany(UserModel, {
   through: "Follow",
   foreignKey: "userId",
-  as: "followers",
+  as: "follower",
   onDelete: "CASCADE",
 });
 UserModel.belongsToMany(UserModel, {

--- a/src/models/tags.js
+++ b/src/models/tags.js
@@ -25,7 +25,12 @@ const TagModel = sequelize.define("Tag", {
 
 ArticleModel.hasMany(TagModel, {
   foreignKey: "articleId",
-  as: "tags",
+  as: "tagList",
+  onDelete: "CASCADE",
+});
+TagModel.belongsTo(ArticleModel, {
+  foreignKey: "articleId",
+  as: "tagList",
   onDelete: "CASCADE",
 });
 

--- a/src/routes/articles.js
+++ b/src/routes/articles.js
@@ -1,9 +1,10 @@
 import { Router } from "express";
 import { deserializeUser } from "../middleware/deserializeUser";
-import { handleCreateArticle } from "../controllers/articles";
+import { handleCreateArticle, handleQueryOneArticle } from "../controllers/articles";
 
 const router = Router();
 
 router.post("/", deserializeUser, handleCreateArticle);
+router.get("/:slug",handleQueryOneArticle)
 
 export default router;

--- a/src/utils/errorHandleUtils.js
+++ b/src/utils/errorHandleUtils.js
@@ -33,7 +33,7 @@ export const errorHandles = [
     statusCode: 400
   },
   {
-    message: "user query does not exist",
+    message: "query does not exist",
     statusCode: 404
   },
 ]

--- a/test/integration/articleControllerUtils.test.js
+++ b/test/integration/articleControllerUtils.test.js
@@ -1,8 +1,12 @@
 import {
   articleDbPayload,
   expectArticlePayload,
+  expectQueryArticlePayload,
 } from "../utils/articlesTestValue";
-import { createArticle } from "../../src/utils/articleControllerUtils";
+import {
+  createArticle,
+  queryOneArticle,
+} from "../../src/utils/articleControllerUtils";
 import { createUser } from "../../src/utils/userControllerUtils";
 import UserModel from "../../src/models/users";
 
@@ -11,7 +15,7 @@ const user = {
   username: "person",
   hash: "(Salt)y(Hash)browns",
 };
-describe("Integration tests for profile controller utils", () => {
+describe("Integration tests for article controller utils", () => {
   beforeAll(async () => {
     await createUser(user);
   });
@@ -41,7 +45,8 @@ describe("Integration tests for profile controller utils", () => {
     });
     describe("Given valid body payload with invalid tagList", () => {
       it("should return article db payload", async () => {
-        const { tagList, ...articleDbPayloadCase2 } = expectArticlePayload.article;
+        const { tagList, ...articleDbPayloadCase2 } =
+          expectArticlePayload.article;
         const newArticle = await createArticle(user.email, {
           ...articleDbPayload,
           title: "newer article",
@@ -57,6 +62,21 @@ describe("Integration tests for profile controller utils", () => {
         } catch (e) {
           expect(e.message).toEqual("Payload value(s) not unique");
         }
+      });
+    });
+  });
+
+  describe("Test functionality of queryOneArticlePayload()", () => {
+    describe("Given slug query exists", () => {
+      it("should return query one article db payload", async () => {
+        const query = await queryOneArticle(articleDbPayload.slug);
+        expect(query).toEqual(expectQueryArticlePayload.article);
+      });
+    });
+    describe("Given slug query does not exist ", () => {
+      it("should return null", async () => {
+        const query = await queryOneArticle("i-don't-exist");
+        expect(query).toBeNull();
       });
     });
   });

--- a/test/utils/articlesTestValue.js
+++ b/test/utils/articlesTestValue.js
@@ -1,5 +1,7 @@
+// POST ARTICLE
 export const articleDbPayload = {
   title: "Click bait here",
+  slug: "click-bait-here",
   description: "real and true",
   body: "Life hacks",
   tagList: ["new", "hacks"],
@@ -28,5 +30,44 @@ export const expectArticlePayload = {
     description: expect.any(String),
     body: expect.any(String),
     tagList: expect.toBeOneOf([undefined, null, expect.any(Array)]),
+  },
+};
+// GET ARTICLE
+export const expectQueryArticlePayload = {
+  article: {
+    slug: expect.any(String),
+    title: expect.any(String),
+    description: expect.any(String),
+    body: expect.any(String),
+    tagList: expect.any(Array),
+    createdAt: expect.toBeOneOf([expect.any(Date), expect.any(String)]),
+    updatedAt: expect.toBeOneOf([expect.any(Date), expect.any(String)]),
+    favorited: expect.any(Boolean),
+    favoritesCount: expect.any(Number), // signed number positive (add in test)
+    author: {
+      username: expect.any(String),
+      bio: expect.toBeOneOf([null, expect.any(String)]),
+      image: expect.toBeOneOf([null, expect.any(String)]),
+      following: expect.any(Boolean),
+    },
+  },
+};
+export const queryArticleDbPayload = {
+  article: {
+    slug: "slug-slug-slug",
+    title: "slug Slug sLuG",
+    description: "explain slug",
+    body: "explaination here",
+    tagList: ["slug", "tutorial"],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    favorited: false,
+    favoritesCount: 0, // signed number positive (add in test)
+    author: {
+      username: "user",
+      bio: null,
+      image: null,
+      following: false,
+    },
   },
 };


### PR DESCRIPTION
# Summary
In this PR, I created a get request for the end point `/api/articles/:slug`. I created a controller that uses the params provided in the endpoint to query the database (db) for the article. The `queryOneArticle()` function uses the param variable to search the db for the article and the associations to match the payload format. Then the database payload is formatted to be sent back to the requester.

# Screenshots of the PR
<img width="549" alt="Screenshot 2022-10-21 at 12 38 37 PM" src="https://user-images.githubusercontent.com/60503218/197250750-3d5ac474-d22b-4625-b371-70251887624f.png">
<img width="835" alt="Screenshot 2022-10-21 at 12 39 08 PM" src="https://user-images.githubusercontent.com/60503218/197250768-2aa58ddf-21de-4285-bc87-e82c29eee945.png">
