### PR TITLE
feat: create favorite article route

### DIFF
--- a/docs/articles.md
+++ b/docs/articles.md
@@ -1,10 +1,164 @@
-# Articles 
+# Articles
 
 ## Create Article
 
 ### Endpoint: `POST` `/api/articles`
 
 ### Authentication header required
+
+Authentication header Type:
+| Name | Type |
+|:-----|:-----|
+| `Authorization` | `String` |
+
+### Authentication header example:
+
+```JSON
+{
+  "Authorization": "Bearer jwt.token.here"
+}
+```
+
+### Request Body Type:
+
+| Name                     | Type            |
+| :----------------------- | :-------------- |
+| `article` _required_     | `Object`        |
+| `title` _required_       | `String`        |
+| `description` _required_ | `String`        |
+| `body` _required_        | `String`        |
+| `tagList`                | `Array or null` |
+
+### Request Body Example:
+
+```JSON
+{
+     "user": {
+         "username": "example",
+         "email": "example@example.example",
+         "password": "1exampleword"
+     }
+}
+```
+
+### Response Body Type:
+
+| Name          | Type                 |
+| :------------ | :------------------- |
+| `article`     | `Object`             |
+| `title`       | `String`             |
+| `description` | `String`             |
+| `body`        | `String`             |
+| `tagList`     | `Array or undefined` |
+
+### Response Body Example:
+
+```JSON
+{
+     "article": {
+         "title": "example",
+         "description": "This is an example",
+         "body": "I love examples",
+         "tagList": ["example", "new"],
+     }
+}
+```
+
+```JSON
+{
+     "article": {
+         "title": "example",
+         "description": "This is an example",
+         "body": "I love examples",
+     }
+}
+```
+
+### Errors:
+
+> #### `StatusCode` `400` - Invalid request body
+>
+> Must provide required body content listed above or invalid email type provided
+>
+> #### `StatusCode` `422` - Payload value(s) not unqiue
+>
+> The requested email or username creation is already taken by another user
+>
+> #### `StatusCode` `403` - Unauthorized
+>
+> This error will redirect user to homepage.
+>
+> Authorization header not provided, Expired JWT token, Invalid JWT token
+
+## Query Article
+
+### Endpoint: `GET` `/api/articles/:slug`
+
+### Authentication header not required
+
+### Params:
+
+| Name              | Type     |
+| :---------------- | :------- |
+| `slug` _required_ | `String` |
+
+### Response Body Type:
+
+| Name             | Type             |
+| :--------------- | :--------------- |
+| `article`        | `Object`         |
+| `title`          | `String`         |
+| `description`    | `String`         |
+| `body`           | `String`         |
+| `createdAt`      | `Date or String` |
+| `updatedAt`      | `Date or String` |
+| `favorited`      | `Boolean`        |
+| `favoritesCount` | `Number`         |
+| `Author`         | `Object`         |
+| `username`       | `String`         |
+| `bio`            | `String`         |
+| `image`          | `String`         |
+| `following`      | `Boolean`        |
+
+### Response Body Example:
+
+```JSON
+{
+    "article": {
+        "slug": "how-to-train-your-dragon",
+        "title": "How to train your dragon",
+        "description": "Ever wonder how?",
+        "body": "It takes a Jacobian",
+        "tagList": ["dragons", "training"],
+        "createdAt": "2016-02-18T03:22:56.637Z",
+        "updatedAt": "2016-02-18T03:48:35.824Z",
+        "favorited": false,
+        "favoritesCount": 0,
+        "author": {
+            "username": "jake",
+            "bio": "I work at statefarm",
+            "image": "https://i.stack.imgur.com/xHWG8.jpg",
+            "following": false
+        }
+    }
+}
+```
+
+
+### Errors:
+> #### `StatusCode` `400` - Invalid request body
+>
+> Must provide required params content listed above
+> #### `StatusCode` `404` - Invalid request body
+>
+> Slug provided in params does not exist
+
+
+## Favorite Article
+
+### Endpoint: `POST` `/api/articles/:slug/favorite`
+
+### Authentication required
 
  Authentication header Type: 
 | Name | Type |
@@ -17,63 +171,63 @@
   "Authorization": "Bearer jwt.token.here"
 }
 ```
-
-### Request Body Type:
+### Params:
 
 | Name | Type |
 |:-----|:-----|
-| `article` *required* | `Object` |
-| `title` *required*| `String` |
-| `description` *required*| `String` |
-| `body` *required*| `String` |
-| `tagList` | `Array or null` |
+| `slug` *required*| `String` |
 
-### Request Body Example:
-```JSON 
-{
-     "user": {
-         "username": "example",    
-         "email": "example@example.example",
-         "password": "1exampleword"
-     }
-} 
-```
 ### Response Body Type:
-| Name | Type |
-|:-----|:-----|
-| `article` | `Object` |
-| `title` | `String` |
-| `description` | `String` |
-| `body` | `String` |
-| `tagList` | `Array or undefined` |
+
+| Name             | Type             |
+| :--------------- | :--------------- |
+| `article`        | `Object`         |
+| `title`          | `String`         |
+| `description`    | `String`         |
+| `body`           | `String`         |
+| `createdAt`      | `Date or String` |
+| `updatedAt`      | `Date or String` |
+| `favorited`      | `Boolean`        |
+| `favoritesCount` | `Number`         |
+| `Author`         | `Object`         |
+| `username`       | `String`         |
+| `bio`            | `String`         |
+| `image`          | `String`         |
+| `following`      | `Boolean`        |
 
 ### Response Body Example:
-```JSON 
+
+```JSON
 {
-     "article": {
-         "title": "example",    
-         "description": "This is an example",    
-         "body": "I love examples",
-         "tagList": ["example", "new"],
-     }
-} 
-```
-```JSON 
-{
-     "article": {
-         "title": "example",    
-         "description": "This is an example",    
-         "body": "I love examples",
-     }
-} 
+    "article": {
+        "slug": "how-to-train-your-dragon",
+        "title": "How to train your dragon",
+        "description": "Ever wonder how?",
+        "body": "It takes a Jacobian",
+        "tagList": ["dragons", "training"],
+        "createdAt": "2016-02-18T03:22:56.637Z",
+        "updatedAt": "2016-02-18T03:48:35.824Z",
+        "favorited": false,
+        "favoritesCount": 0,
+        "author": {
+            "username": "jake",
+            "bio": "I work at statefarm",
+            "image": "https://i.stack.imgur.com/xHWG8.jpg",
+            "following": false
+        }
+    }
+}
 ```
 ### Errors:
 > #### `StatusCode` `400` - Invalid request body
 >
-> Must provide required body content listed above or invalid email type provided
+> Must provide required params content listed above
+> #### `StatusCode` `404` - Invalid request body
+>
+> Slug provided in params does not exist
 > #### `StatusCode` `422` - Payload value(s) not unqiue
 >
-> The requested email or username creation is already taken by another user 
+> The current user already favorited the requested article 
 > #### `StatusCode` `403` - Unauthorized
 >
 > This error will redirect user to homepage. 

--- a/src/controllers/articles.js
+++ b/src/controllers/articles.js
@@ -3,7 +3,8 @@ import {
   createArticle,
   queryOneArticle,
   createArticlePayloadFormat,
-  queryOneArticlePayloadFormat
+  queryOneArticlePayloadFormat,
+  favoriteArticle,
 } from "../utils/articleControllerUtils";
 import { errorHandles } from "../utils/errorHandleUtils";
 
@@ -51,6 +52,27 @@ export async function handleQueryOneArticle(req, res) {
     const payload = queryOneArticlePayloadFormat(query);
 
     return res.status(200).json(payload);
+  } catch (e) {
+    console.error(e);
+
+    const error = errorHandles.find(({ message }) => message === e.message);
+
+    if (!error) return res.status(500).send("Server Error");
+
+    return res.status(error.statusCode).send(error.message);
+  }
+}
+export async function handleFavoriteArticle(req, res) {
+  try {
+    const query = queryOneArticle(req.params.slug);
+    if (!query) throw new Error("query does not exist");
+
+    await favoriteArticle(req.user.email, query.id);
+    await query.save();
+
+    const payload = queryOneArticlePayloadFormat(query);
+
+    return res.status(201).json(payload);
   } catch (e) {
     console.error(e);
 

--- a/src/models/favorties.js
+++ b/src/models/favorties.js
@@ -11,14 +11,6 @@ const FavoriteModel = sequelize.define("Favorite", {
     allownull: false,
     defaultValue: DataTypes.UUIDV4,
   },
-  articleId: {
-    type: DataTypes.UUID,
-    allownull: false,
-    references: {
-      model: ArticleModel,
-      key: "id",
-    },
-  },
   userId: {
     type: DataTypes.STRING,
     allownull: false,
@@ -27,16 +19,24 @@ const FavoriteModel = sequelize.define("Favorite", {
       key: "email",
     },
   },
+  articleId: {
+    type: DataTypes.UUID,
+    allownull: false,
+    references: {
+      model: ArticleModel,
+      key: "id",
+    },
+  },
 });
 
 UserModel.belongsToMany(ArticleModel, {
-  through: "Favorite",
+  through: FavoriteModel,
   as: "isFavorite",
   foreignKey: "userId",
   onDelete: "CASCADE",
 });
 ArticleModel.belongsToMany(UserModel, {
-  through: "Favorite",
+  through: FavoriteModel,
   as: "favoritesCount",
   foreignKey: "articleId",
   onDelete: "CASCADE",

--- a/src/models/follows.js
+++ b/src/models/follows.js
@@ -21,7 +21,6 @@ const FollowModel = sequelize.define("Follow", {
   followingId: {
     type: DataTypes.STRING,
     allownull: false,
-    unique: true,
     references: {
       model: UserModel,
       key: "email",

--- a/src/routes/articles.js
+++ b/src/routes/articles.js
@@ -1,10 +1,11 @@
 import { Router } from "express";
 import { deserializeUser } from "../middleware/deserializeUser";
-import { handleCreateArticle, handleQueryOneArticle } from "../controllers/articles";
+import { handleCreateArticle, handleQueryOneArticle, handleFavoriteArticle } from "../controllers/articles";
 
 const router = Router();
 
 router.post("/", deserializeUser, handleCreateArticle);
-router.get("/:slug",handleQueryOneArticle)
+router.get("/:slug", handleQueryOneArticle)
+router.post("/:slug/favorite", deserializeUser, handleFavoriteArticle)
 
 export default router;

--- a/src/utils/articleControllerUtils.js
+++ b/src/utils/articleControllerUtils.js
@@ -31,7 +31,7 @@ export async function createArticle(userEmail, article) {
     return newArticlePayload;
   } catch (e) {
     console.error(e);
-    if (e.name === "SequelizeUniqueContraintError") {
+    if (e.name === "SequelizeUniqueConstraintError") {
       throw new Error("Payload value(s) not unique");
     }
     return null;
@@ -42,6 +42,7 @@ export async function queryOneArticle(slug) {
     const query = await ArticleModel.findOne({
       where: { slug: slug },
       attributes: [
+        "id",
         "slug",
         "title",
         "description",
@@ -82,14 +83,14 @@ export async function queryOneArticle(slug) {
       ],
     });
     const payload = query.get({ plain: true });
-    payload.favoritesCount = payload?.favoritesCount?.length || 0;
+    payload.favoritesCount = payload.favoritesCount.length || 0;
     payload.favorited = false;
-    payload.tagList = payload?.tagList.map(({ tag }) => tag);
+    payload.tagList = payload.tagList.map(({ tag }) => tag);
     payload.author.following = payload.author.following.length > 0;
     return payload;
   } catch (e) {
-    console.error(e)
-    return null
+    console.error(e);
+    return null;
   }
 }
 export function queryOneArticlePayloadFormat(article) {
@@ -112,6 +113,20 @@ export function queryOneArticlePayloadFormat(article) {
       },
     },
   };
+}
+export async function favoriteArticle(userId, articleId) {
+  try {
+    await FavoriteModel.create({
+      userId: userId,
+      articleId: articleId,
+    });
+  } catch (e) {
+    if (e.name === "SequelizeUniqueConstraintError") {
+      throw new Error("Payload value(s) not unique");
+    } else {
+      throw new Error(e);
+    }
+  }
 }
 export function createArticlePayloadFormat(article) {
   return {

--- a/test/end-to-end/articles.test.js
+++ b/test/end-to-end/articles.test.js
@@ -1,5 +1,5 @@
 import supertest from "supertest";
-import createServer from "../../src/utils/serverSetup"
+import createServer from "../../src/utils/serverSetup";
 import {
   articleDbPayload,
   expectArticlePayload,
@@ -9,17 +9,17 @@ import {
   expectQueryArticlePayload,
   queryArticleDbPayload,
 } from "../utils/articlesTestValue";
-import { verifyTokenPayload, dbPayload } from "../utils/testValues"
+import { verifyTokenPayload, dbPayload } from "../utils/testValues";
 import { deserializeUser } from "../../src/middleware/deserializeUser";
-import * as jwtUtils from "../../src/utils/jwtUtils"
-import * as articleControllerUtils from "../../src/utils/articleControllerUtils"
+import * as jwtUtils from "../../src/utils/jwtUtils";
+import * as articleControllerUtils from "../../src/utils/articleControllerUtils";
 
 const app = createServer();
 
 describe("test article route", () => {
   describe("POST /api/articles - Article creation", () => {
     describe("Given request payload is valid and current user is authenticated", () => {
-      let token = ""
+      let token = "";
       beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
       it("should return status 201 and article payload", async () => {
         //middleware init
@@ -42,7 +42,7 @@ describe("test article route", () => {
         const { body, statusCode } = await supertest(app)
           .post("/api/articles")
           .set("Authorization", `Bearer ${token}`)
-          .send(articlePayload)
+          .send(articlePayload);
 
         await deserializeUser(mockReq, mockRes, mockNext);
 
@@ -65,7 +65,7 @@ describe("test article route", () => {
       });
     });
     describe("Given request payload is empty and current user is authenticated", () => {
-      let token = ""
+      let token = "";
       beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
       it("should return status 400", async () => {
         //middleware init
@@ -105,7 +105,7 @@ describe("test article route", () => {
       });
     });
     describe("Given invalid payload format", () => {
-      let token = ""
+      let token = "";
       beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
       it("should return status 400", async () => {
         //middleware init
@@ -121,14 +121,15 @@ describe("test article route", () => {
 
         // end of middleware init
 
-        const createArticleMock = jest
-          .spyOn(articleControllerUtils, "createArticle")
+        const createArticleMock = jest.spyOn(
+          articleControllerUtils,
+          "createArticle"
+        );
 
         const { statusCode } = await supertest(app)
           .post("/api/articles")
           .set("Authorization", `Bearer ${token}`)
-          .send(invalidArticlePayloadFormat)
-
+          .send(invalidArticlePayloadFormat);
 
         await deserializeUser(mockReq, mockRes, mockNext);
 
@@ -146,7 +147,7 @@ describe("test article route", () => {
       });
     });
     describe("Given valid payload, but tagList type is invalid", () => {
-      let token = ""
+      let token = "";
       beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
       it("should return status 400", async () => {
         //middleware init
@@ -169,7 +170,7 @@ describe("test article route", () => {
         const { statusCode } = await supertest(app)
           .post("/api/articles")
           .set("Authorization", `Bearer ${token}`)
-          .send(invalidTaglistPayload)
+          .send(invalidTaglistPayload);
 
         await deserializeUser(mockReq, mockRes, mockNext);
 
@@ -187,7 +188,7 @@ describe("test article route", () => {
       });
     });
     describe("Given request payload is not unique, and current user is authenticated", () => {
-      let token = ""
+      let token = "";
       beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
       it("should return status 422", async () => {
         //middleware init
@@ -210,7 +211,7 @@ describe("test article route", () => {
         const { statusCode } = await supertest(app)
           .post("/api/articles")
           .set("Authorization", `Bearer ${token}`)
-          .send(articlePayload)
+          .send(articlePayload);
 
         await deserializeUser(mockReq, mockRes, mockNext);
 
@@ -231,7 +232,7 @@ describe("test article route", () => {
       });
     });
   });
-  //GET 
+  //GET /api/articles/:slug
 
   describe("GET /api/articles/:slug - Get queried article", () => {
     describe("Given article query exists", () => {
@@ -240,8 +241,9 @@ describe("test article route", () => {
           .spyOn(articleControllerUtils, "queryOneArticle")
           .mockReturnValueOnce(queryArticleDbPayload.article);
 
-        const { body, statusCode } = await supertest(app)
-          .get("/api/articles/slug-slug-slug")
+        const { body, statusCode } = await supertest(app).get(
+          "/api/articles/slug-slug-slug"
+        );
 
         expect(statusCode).toBe(200);
 
@@ -258,15 +260,172 @@ describe("test article route", () => {
       it("should return status 404", async () => {
         const queryOneArticleMock = jest
           .spyOn(articleControllerUtils, "queryOneArticle")
-          .mockReturnValueOnce(null)
+          .mockReturnValueOnce(null);
 
-        const { statusCode } = await supertest(app)
-          .get("/api/articles/slug-slug-slug")
+        const { statusCode } = await supertest(app).get(
+          "/api/articles/slug-slug-slug"
+        );
 
         expect(statusCode).toBe(404);
 
         expect(queryOneArticleMock).toHaveBeenCalledWith(
           queryArticleDbPayload.article.slug
+        );
+      });
+    });
+  });
+
+  // POST /api/articles/:slug/favorite
+  describe("POST /api/articles/:slug/favorite - favorite article", () => {
+    describe("Given query is valid and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 201 and article payload", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+        const modelInstanceMock = { ...queryArticleDbPayload.article, save: jest.fn(() => queryArticleDbPayload.article) }
+
+        const queryOneArticleMock = jest
+          .spyOn(articleControllerUtils, "queryOneArticle")
+          .mockReturnValueOnce(modelInstanceMock);
+
+        const favoriteArticleMock = jest.spyOn(
+          articleControllerUtils,
+          "favoriteArticle"
+        ).mockReturnValueOnce(void 0)
+
+        const { body, statusCode } = await supertest(app)
+          .post("/api/articles/slug-slug-slug/favorite")
+          .set("Authorization", `Bearer ${token}`);
+
+        console.log(body)
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(201);
+
+        expect(body).toEqual(expectQueryArticlePayload);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleMock).toHaveBeenCalledWith(
+          queryArticleDbPayload.article.slug
+        );
+        expect(favoriteArticleMock).toHaveBeenCalledWith(
+          "new@new.new",
+          "ID of Article"
+        );
+        expect(modelInstanceMock.save).toHaveBeenCalled()
+      });
+    });
+    describe("Given query does not exist and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 400", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const queryOneArticleMock = jest
+          .spyOn(articleControllerUtils, "queryOneArticle")
+          .mockReturnValueOnce(null);
+        const favoriteArticleMock = jest.spyOn(
+          articleControllerUtils,
+          "favoriteArticle"
+        )
+
+        const { statusCode } = await supertest(app)
+          .post("/api/articles/slug-slug-slug/favorite")
+          .set("Authorization", `Bearer ${token}`);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(404);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleMock).toHaveBeenCalledWith(
+          queryArticleDbPayload.article.slug
+        );
+        expect(favoriteArticleMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Given query is already favorited and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 422", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const queryOneArticleMock = jest
+          .spyOn(articleControllerUtils, "queryOneArticle")
+          .mockReturnValueOnce(queryArticleDbPayload.article);
+        const favoriteArticleMock = jest
+          .spyOn(articleControllerUtils, "favoriteArticle")
+          .mockRejectedValueOnce(new Error("Payload value(s) not unique"));
+
+        const { statusCode } = await supertest(app)
+          .post("/api/articles/slug-slug-slug/favorite")
+          .set("Authorization", `Bearer ${token}`)
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(422);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleMock).toHaveBeenCalledWith(
+          queryArticleDbPayload.article.slug
+        );
+        expect(favoriteArticleMock).toHaveBeenCalledWith(
+          verifyTokenPayload.email,
+          "ARTICLE ID HERE"
         );
       });
     });

--- a/test/integration/articleControllerUtils.test.js
+++ b/test/integration/articleControllerUtils.test.js
@@ -5,6 +5,7 @@ import {
 } from "../utils/articlesTestValue";
 import {
   createArticle,
+  favoriteArticle,
   queryOneArticle,
 } from "../../src/utils/articleControllerUtils";
 import { createUser } from "../../src/utils/userControllerUtils";
@@ -70,13 +71,32 @@ describe("Integration tests for article controller utils", () => {
     describe("Given slug query exists", () => {
       it("should return query one article db payload", async () => {
         const query = await queryOneArticle(articleDbPayload.slug);
-        expect(query).toEqual(expectQueryArticlePayload.article);
+        expect(query).toEqual({...expectQueryArticlePayload.article, id: expect.any(String)});
       });
     });
     describe("Given slug query does not exist ", () => {
       it("should return null", async () => {
         const query = await queryOneArticle("i-don't-exist");
         expect(query).toBeNull();
+      });
+    });
+  });
+
+  describe("Test functionality of favoriteArticle()", () => {
+    let articleId = ""
+    beforeAll(async () => articleId = await queryOneArticle(articleDbPayload.slug))
+    describe("Given valid user and article id", () => {
+      it("should add user id and article id to favorite table", async () => {
+        await expect(await favoriteArticle(user.email,articleId.id)).toBe(undefined) // void function
+      });
+    });
+    describe("Given user id or article id already in table  ", () => {
+      it("should throw error", async () => {
+        try{
+          await favoriteArticle(user.email,articleId.id)
+        }catch(e){
+          expect(e.message).toEqual("Payload value(s) not unique") 
+        }
       });
     });
   });

--- a/test/utils/articlesTestValue.js
+++ b/test/utils/articlesTestValue.js
@@ -54,6 +54,7 @@ export const expectQueryArticlePayload = {
 };
 export const queryArticleDbPayload = {
   article: {
+    id: expect.any(String),
     slug: "slug-slug-slug",
     title: "slug Slug sLuG",
     description: "explain slug",


### PR DESCRIPTION
# Summary
In this PR I created a route that favorites an article. This route uses an authentication middleware which would be used to check the current user that would be liking the article post. The controller queries the database using the slug provided in the params.  I created a Favorites table schema to track users favorite articles. The table is a many-to-many relationship between articles and users. Then, the article id and user id are added to the Favorites table in the database.

# Screenshot of PR
![Screenshot 2022-10-24 at 5 56 09 PM](https://user-images.githubusercontent.com/60503218/197646968-87a5e66e-2e1e-4826-ab7e-4852b6d08b29.png)
![Screenshot 2022-10-24 at 5 56 22 PM](https://user-images.githubusercontent.com/60503218/197646976-11634477-c1f3-4ca3-8cf4-ebc210536e5a.png)
