### PR TITLE
feat: create PUT /api/articles/:slug route

### DIFF
--- a/docs/articles.md
+++ b/docs/articles.md
@@ -33,10 +33,11 @@ Authentication header Type:
 
 ```JSON
 {
-     "user": {
-         "username": "example",
-         "email": "example@example.example",
-         "password": "1exampleword"
+     "article": {
+         "title": "example",
+         "description": "This is an example",
+         "body": "I love examples",
+         "tagList": ["example","new"]
      }
 }
 ```
@@ -153,6 +154,103 @@ Authentication header Type:
 >
 > Slug provided in params does not exist
 
+## Update Article
+
+### Endpoint: `PUT` `/api/articles/:slug`
+
+### Authentication header required
+
+Authentication header Type:
+| Name | Type |
+|:-----|:-----|
+| `Authorization` | `String` |
+
+### Authentication header example:
+
+```JSON
+{
+  "Authorization": "Bearer jwt.token.here"
+}
+```
+
+### Request Body Type:
+At least one of: `title`, `description`, `body` must be provided
+
+| Name                     | Type            |
+| :----------------------- | :-------------- |
+| `article` _required_     | `Object`        |
+| `title` _optional_       | `String`        |
+| `description` _optional_ | `String`        |
+| `body` _optional_        | `String`        |
+
+### Request Body Example:
+
+```JSON
+{
+     "article": {
+         "title": "New Title"
+     }
+}
+```
+### Params:
+
+| Name              | Type     |
+| :---------------- | :------- |
+| `slug` _required_ | `String` |
+
+### Response Body Type:
+
+| Name             | Type             |
+| :--------------- | :--------------- |
+| `article`        | `Object`         |
+| `title`          | `String`         |
+| `description`    | `String`         |
+| `body`           | `String`         |
+| `createdAt`      | `Date or String` |
+| `updatedAt`      | `Date or String` |
+| `favorited`      | `Boolean`        |
+| `favoritesCount` | `Number`         |
+| `Author`         | `Object`         |
+| `username`       | `String`         |
+| `bio`            | `String`         |
+| `image`          | `String`         |
+| `following`      | `Boolean`        |
+
+### Response Body Example:
+
+```JSON
+{
+    "article": {
+        "slug": "how-to-train-your-dragon",
+        "title": "How to train your dragon",
+        "description": "Ever wonder how?",
+        "body": "It takes a Jacobian",
+        "tagList": ["dragons", "training"],
+        "createdAt": "2016-02-18T03:22:56.637Z",
+        "updatedAt": "2016-02-18T03:48:35.824Z",
+        "favorited": false,
+        "favoritesCount": 0,
+        "author": {
+            "username": "jake",
+            "bio": "I work at statefarm",
+            "image": "https://i.stack.imgur.com/xHWG8.jpg",
+            "following": false
+        }
+    }
+}
+```
+
+
+### Errors:
+> #### `StatusCode` `400` - Invalid request body
+>
+> Must provide required params content listed above
+> #### `StatusCode` `404` - Invalid request body
+>
+> Slug provided in params does not exist
+> #### `StatusCode` `422` - Request body not unique
+>
+> Requested title is already taken
 
 ## Favorite Article
 

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -1,4 +1,4 @@
-import { validateBody, validateEmail } from "../utils/validators";
+import { removeNull, validateBody, validateEmail } from "../utils/validators";
 import {
   createUser,
   updateUserInputFormat,
@@ -40,7 +40,6 @@ export async function registerUser(req, res) {
     return res.status(201).json(userPayload);
   } catch (e) {
     console.error(e);
-
 
     const error = errorHandles.find(({ message }) => message === e.message);
 
@@ -104,7 +103,13 @@ export async function updateUser(req, res) {
     if (!user) {
       throw new Error("No payload found");
     }
-    const formattedUser = updateUserInputFormat(user);
+    const formatPayload = {
+      username: user.username || null,
+      password: user.password || null,
+      bio: user.bio || null,
+      image: user.image || null,
+    };
+    const formattedUser = removeNull(formatPayload);
     if (!formattedUser) {
       throw new Error("Invalid payload format");
     }

--- a/src/routes/articles.js
+++ b/src/routes/articles.js
@@ -1,11 +1,12 @@
 import { Router } from "express";
 import { deserializeUser } from "../middleware/deserializeUser";
-import { handleCreateArticle, handleQueryOneArticle, handleFavoriteArticle, handleUnFavoriteArticle } from "../controllers/articles";
+import { handleCreateArticle, handleQueryOneArticle, handleFavoriteArticle, handleUnFavoriteArticle, handleUpdateArticle } from "../controllers/articles";
 
 const router = Router();
 
 router.post("/", deserializeUser, handleCreateArticle);
 router.get("/:slug", handleQueryOneArticle)
+router.put("/:slug",deserializeUser, handleUpdateArticle )
 router.post("/:slug/favorite", deserializeUser, handleFavoriteArticle)
 router.delete("/:slug/favorite", deserializeUser, handleUnFavoriteArticle)
 

--- a/src/utils/userControllerUtils.js
+++ b/src/utils/userControllerUtils.js
@@ -45,22 +45,6 @@ export async function queryOneUserAndUpdate(email, payload) {
   }
 }
 
-export function updateUserInputFormat(user) {
-  const removeNull = {
-    username: user.username || null,
-    password: user.password || null,
-    bio: user.bio || null,
-    image: user.image || null,
-  };
-  Object.keys(removeNull).forEach((key) => {
-    if (!removeNull[key]) {
-      delete removeNull[key];
-    }
-  });
-  if (Object.keys(removeNull).length === 0) return null;
-  return removeNull;
-}
-
 export function userPayloadFormat(payload) {
   return {
     user: {

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -40,3 +40,12 @@ export function validateTagList(tags){
   return isValid
 }
 
+export function removeNull(payload) {
+  Object.keys(payload).forEach((key) => {
+    if (!payload[key]) {
+      delete payload[key];
+    }
+  });
+  if (Object.keys(payload).length === 0) return null;
+  return payload;
+}

--- a/test/end-to-end/articles.test.js
+++ b/test/end-to-end/articles.test.js
@@ -293,16 +293,18 @@ describe("test article route", () => {
           .mockReturnValueOnce(verifyTokenPayload);
 
         // end of middleware init
-        const modelInstanceMock = { ...queryArticleDbPayload.article, save: jest.fn(() => queryArticleDbPayload.article) }
+        const modelInstanceMock = {
+          ...queryArticleDbPayload.article,
+          save: jest.fn(() => queryArticleDbPayload.article),
+        };
 
         const queryOneArticleMock = jest
           .spyOn(articleControllerUtils, "queryOneArticle")
           .mockReturnValueOnce(modelInstanceMock);
 
-        const favoriteArticleMock = jest.spyOn(
-          articleControllerUtils,
-          "favoriteArticle"
-        ).mockReturnValueOnce(void 0)
+        const favoriteArticleMock = jest
+          .spyOn(articleControllerUtils, "favoriteArticle")
+          .mockReturnValueOnce(void 0);
 
         const { body, statusCode } = await supertest(app)
           .post("/api/articles/slug-slug-slug/favorite")
@@ -329,7 +331,7 @@ describe("test article route", () => {
           "new@new.new",
           "ID of Article"
         );
-        expect(modelInstanceMock.save).toHaveBeenCalled()
+        expect(modelInstanceMock.save).toHaveBeenCalled();
       });
     });
     describe("Given query does not exist and current user is authenticated", () => {
@@ -355,7 +357,7 @@ describe("test article route", () => {
         const favoriteArticleMock = jest.spyOn(
           articleControllerUtils,
           "favoriteArticle"
-        )
+        );
 
         const { statusCode } = await supertest(app)
           .post("/api/articles/slug-slug-slug/favorite")
@@ -405,7 +407,7 @@ describe("test article route", () => {
 
         const { statusCode } = await supertest(app)
           .post("/api/articles/slug-slug-slug/favorite")
-          .set("Authorization", `Bearer ${token}`)
+          .set("Authorization", `Bearer ${token}`);
 
         await deserializeUser(mockReq, mockRes, mockNext);
 
@@ -448,16 +450,18 @@ describe("test article route", () => {
           .mockReturnValueOnce(verifyTokenPayload);
 
         // end of middleware init
-        const modelInstanceMock = { ...queryArticleDbPayload.article, save: jest.fn(() => queryArticleDbPayload.article) }
+        const modelInstanceMock = {
+          ...queryArticleDbPayload.article,
+          save: jest.fn(() => queryArticleDbPayload.article),
+        };
 
         const queryOneArticleMock = jest
           .spyOn(articleControllerUtils, "queryOneArticle")
           .mockReturnValueOnce(modelInstanceMock);
 
-        const unFavoriteArticleMock = jest.spyOn(
-          articleControllerUtils,
-          "unFavoriteArticle"
-        ).mockReturnValueOnce(void 0)
+        const unFavoriteArticleMock = jest
+          .spyOn(articleControllerUtils, "unFavoriteArticle")
+          .mockReturnValueOnce(void 0);
 
         const { body, statusCode } = await supertest(app)
           .delete("/api/articles/slug-slug-slug/favorite")
@@ -484,7 +488,7 @@ describe("test article route", () => {
           "new@new.new",
           "ID of Article"
         );
-        expect(modelInstanceMock.save).toHaveBeenCalled()
+        expect(modelInstanceMock.save).toHaveBeenCalled();
       });
     });
     describe("Given query does not exist and current user is authenticated", () => {
@@ -510,7 +514,7 @@ describe("test article route", () => {
         const unFavoriteArticleMock = jest.spyOn(
           articleControllerUtils,
           "unFavoriteArticle"
-        )
+        );
 
         const { statusCode } = await supertest(app)
           .delete("/api/articles/slug-slug-slug/favorite")
@@ -560,7 +564,7 @@ describe("test article route", () => {
 
         const { statusCode } = await supertest(app)
           .delete("/api/articles/slug-slug-slug/favorite")
-          .set("Authorization", `Bearer ${token}`)
+          .set("Authorization", `Bearer ${token}`);
 
         await deserializeUser(mockReq, mockRes, mockNext);
 
@@ -581,6 +585,229 @@ describe("test article route", () => {
           verifyTokenPayload.email,
           "ARTICLE ID HERE"
         );
+      });
+    });
+  });
+
+  // PUT /api/articles/:slug
+  describe("PUT /api/articles/:slug - update article", () => {
+    describe("Given request payload is valid and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 201 and article payload", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const queryOneArticleAndUpdateMock = jest
+          .spyOn(articleControllerUtils, "queryOneArticleAndUpdate")
+          .mockReturnValueOnce(queryArticleDbPayload.article);
+
+        const { body, statusCode } = await supertest(app)
+          .put("/api/articles/old-title")
+          .set("Authorization", `Bearer ${token}`)
+          .send({ article: { title: "New Title" } });
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(200);
+
+        expect(body).toEqual(expectQueryArticlePayload);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleAndUpdateMock).toHaveBeenCalledWith({
+          email: verifyTokenPayload.email,
+          payload: expect.any(Object),
+          slug: expect.any(String),
+        });
+      });
+    });
+    describe("Given request payload is empty and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 400", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const queryOneArticleAndUpdateMock = jest
+          .spyOn(articleControllerUtils, "queryOneArticleAndUpdate")
+          .mockReturnValueOnce(queryArticleDbPayload);
+
+        const { statusCode } = await supertest(app)
+          .put("/api/articles/old-title")
+          .set("Authorization", `Bearer ${token}`);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(400);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleAndUpdateMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Given invalid payload format", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 400", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const queryOneArticleAndUpdateMock = jest.spyOn(
+          articleControllerUtils,
+          "queryOneArticleAndUpdate"
+        );
+
+        const { statusCode } = await supertest(app)
+          .put("/api/articles/old-title")
+          .set("Authorization", `Bearer ${token}`)
+          .send(invalidArticlePayloadFormat);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(400);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleAndUpdateMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Given valid payload, but slug does not exist. User is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 404", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const queryOneArticleAndUpdateMock = jest
+          .spyOn(articleControllerUtils, "queryOneArticleAndUpdate")
+          .mockReturnValueOnce(null);
+
+        const { statusCode } = await supertest(app)
+          .put("/api/articles/not-existing-title")
+          .set("Authorization", `Bearer ${token}`)
+          .send({ article: { title: "New Title" } });
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(404);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleAndUpdateMock).toHaveBeenCalledWith({
+          email: verifyTokenPayload.email,
+          payload: expect.any(Object),
+          slug: expect.any(String),
+        });
+      });
+    });
+    describe("Given request payload is not unique, and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 422", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const queryOneArticleAndUpdateMock = jest
+          .spyOn(articleControllerUtils, "queryOneArticleAndUpdate")
+          .mockRejectedValueOnce(new Error("Payload value(s) not unique"));
+
+        const { statusCode } = await supertest(app)
+          .put("/api/articles/old-title")
+          .set("Authorization", `Bearer ${token}`)
+          .send({ article: { title: "Old Title" } });
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(422);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleAndUpdateMock).toHaveBeenCalledWith({
+          email: verifyTokenPayload.email,
+          payload: expect.any(Object),
+          slug: expect.any(String),
+        });
       });
     });
   });

--- a/test/integration/articleControllerUtils.test.js
+++ b/test/integration/articleControllerUtils.test.js
@@ -7,6 +7,7 @@ import {
   createArticle,
   favoriteArticle,
   queryOneArticle,
+  queryOneArticleAndUpdate,
   unFavoriteArticle,
 } from "../../src/utils/articleControllerUtils";
 import { createUser } from "../../src/utils/userControllerUtils";
@@ -123,6 +124,32 @@ describe("Integration tests for article controller utils", () => {
           await unFavoriteArticle(user.email, articleId.id);
         } catch (e) {
           expect(e.message).toEqual("No rows destroyed");
+        }
+      });
+    });
+  });
+
+  describe("Test functionality of queryOneArticleAndUpdate()", () => {
+    describe("Given valid user and slug, and update payload is unique", () => {
+      it("should update selected article and return the updated article", async () => {
+        const updatedArticle = await queryOneArticleAndUpdate({
+          email: user.email,
+          payload: { title: "New New New", slug: "new-new-new" },
+          slug: "click-bait-here",
+        });
+        expect(updatedArticle).toEqual({...expectQueryArticlePayload.article, id: expect.any(String)});
+      });
+    });
+    describe("Given valid user and slug, but update payload is not unique", () => {
+      it("should throw error", async () => {
+        try {
+          await queryOneArticleAndUpdate({
+            email: user.email,
+            payload: { title: "New New New", slug: "new-new-new" },
+            slug: "click-bait-here",
+          });
+        } catch (e) {
+          expect(e.message).toEqual("Payload value(s) not unique");
         }
       });
     });

--- a/test/unit/reqBodyVerification.test.js
+++ b/test/unit/reqBodyVerification.test.js
@@ -1,4 +1,4 @@
-import { validateBody } from "../../src/utils/validators";
+import { validateBody, removeNull } from "../../src/utils/validators";
 
 const expectedVal = {
   1: "string",
@@ -12,9 +12,9 @@ describe("Unit test functionality of validateBody()", () => {
       it("should return false", () => {
         const input = { food: "borger" };
 
-        const valid = validateBody(input,expectedVal) 
+        const valid = validateBody(input, expectedVal);
 
-        expect(valid).toBe(false)
+        expect(valid).toBe(false);
       });
     });
     describe("Types doesn't match - case 1", () => {
@@ -25,9 +25,9 @@ describe("Unit test functionality of validateBody()", () => {
           3: "food",
         };
 
-        const valid = validateBody(input,expectedVal) 
+        const valid = validateBody(input, expectedVal);
 
-        expect(valid).toBe(false)
+        expect(valid).toBe(false);
       });
     });
     describe("Types doesn't match - case 2", () => {
@@ -38,23 +38,68 @@ describe("Unit test functionality of validateBody()", () => {
           3: null,
         };
 
-        const valid = validateBody(input,expectedVal) 
+        const valid = validateBody(input, expectedVal);
 
-        expect(valid).toBe(false)
+        expect(valid).toBe(false);
       });
     });
   });
   describe("Valid inputs", () => {
     it("should return true", () => {
-      const  input = {
+      const input = {
         1: "keyboard",
         2: 1.46,
-        3: null
-      }
+        3: null,
+      };
 
-      const valid = validateBody(input, expectedVal)
+      const valid = validateBody(input, expectedVal);
 
-      expect(valid).toBe(true)
-    })
-  })
+      expect(valid).toBe(true);
+    });
+  });
+});
+describe("Unit test of removeNull()", () => {
+  describe("Given keys all null", () => {
+    it("should return null", () => {
+      const testValues = {
+        something: null,
+        test: null,
+        food: null,
+      };
+      const test = removeNull(testValues);
+
+      expect(test).toEqual(null);
+    });
+  });
+  describe("Given keys has value", () => {
+    it("should only return propeties with values", () => {
+      const update = {
+        email: null,
+        username: "something",
+        password: null,
+        bio: "cool",
+        image: null,
+      };
+      const test = removeNull(update);
+
+      expect(test).toEqual({
+        username: update.username,
+        bio: update.bio,
+      });
+    });
+  });
+  describe("Given key properties with at least 1 key not valued null", () => {
+    it("should return at least key value pair", () => {
+      const update = {
+        email: null,
+        username: null,
+        password: null,
+        bio: "to test or not to test",
+        image: null,
+      };
+      const test = removeNull(update);
+
+      expect(test).toEqual({ bio: update.bio });
+    });
+  });
 });

--- a/test/unit/userControllerUtils.test.js
+++ b/test/unit/userControllerUtils.test.js
@@ -1,5 +1,5 @@
-import { userPayloadFormat, getToken, updateUserInputFormat } from "../../src/utils/userControllerUtils";
-import { dbPayload, invalidCreateUserInput, userPayload } from "../utils/testValues";
+import { userPayloadFormat, getToken  } from "../../src/utils/userControllerUtils";
+import { dbPayload,  userPayload } from "../utils/testValues";
 
 describe("Unit test of userPayloadFormat()", () => {
   describe("Given database object and token to format", () => {
@@ -17,43 +17,6 @@ describe("Unit test of getToken()", () => {
       const test = getToken("Bearer token");
 
       expect(test).toEqual("token");
-    });
-  });
-  describe("Unit test of updateUserInputFormat()", () => {
-    describe("Given keys not related to user properties", () => {
-      it("should return null", () => {
-        const test = updateUserInputFormat(invalidCreateUserInput);
-
-        expect(test).toEqual(null);
-      });
-    });
-    describe("Given keys related to user properties and all values are null", () => {
-      it("should return null", () => {
-        const update = {
-          email: null,
-          username: null,
-          password: null,
-          bio: null,
-          image: null
-        }
-        const test = updateUserInputFormat(update);
-
-        expect(test).toEqual(null);
-      });
-    });
-    describe("Given keys related to user properties with at least 1 key not valued null", () => {
-      it("should return null", () => {
-        const update = {
-          email: null,
-          username: null,
-          password: null,
-          bio: "to test or not to test",
-          image: null
-        }
-        const test = updateUserInputFormat(update);
-
-        expect(test).toEqual({ bio: update.bio });
-      });
     });
   });
 });


### PR DESCRIPTION
# Summary
I created a route that updates existing articles that the current user must be the author of. This route uses an authentication middleware to grab current user data. The controller of this route validates and formats the payload, then checks if the slug provided in the params exists AND belongs to the current user. If the slug provided exists and belongs to the current user, the payload given will query the article in the database and then update with the given payload. Then the updated data will be returned back to the requester.

# Screenshots of the tests
![Screenshot 2022-10-26 at 2 45 16 PM](https://user-images.githubusercontent.com/60503218/198114520-efd4658b-6987-4e66-9d77-1635243c6b82.png)
![Screenshot 2022-10-26 at 2 45 29 PM](https://user-images.githubusercontent.com/60503218/198114539-c8e41151-1d9d-4944-97ca-b80f7e3a0e60.png)
