### PR TITLE
feat: create DELETE /api/articles/:slug

### DIFF
--- a/docs/articles.md
+++ b/docs/articles.md
@@ -33,10 +33,11 @@ Authentication header Type:
 
 ```JSON
 {
-     "user": {
-         "username": "example",
-         "email": "example@example.example",
-         "password": "1exampleword"
+     "article": {
+         "title": "example",
+         "description": "This is an example",
+         "body": "I love examples",
+         "tagList": ["example","new"]
      }
 }
 ```
@@ -153,6 +154,103 @@ Authentication header Type:
 >
 > Slug provided in params does not exist
 
+## Update Article
+
+### Endpoint: `PUT` `/api/articles/:slug`
+
+### Authentication header required
+
+Authentication header Type:
+| Name | Type |
+|:-----|:-----|
+| `Authorization` | `String` |
+
+### Authentication header example:
+
+```JSON
+{
+  "Authorization": "Bearer jwt.token.here"
+}
+```
+
+### Request Body Type:
+At least one of: `title`, `description`, `body` must be provided
+
+| Name                     | Type            |
+| :----------------------- | :-------------- |
+| `article` _required_     | `Object`        |
+| `title` _optional_       | `String`        |
+| `description` _optional_ | `String`        |
+| `body` _optional_        | `String`        |
+
+### Request Body Example:
+
+```JSON
+{
+     "article": {
+         "title": "New Title"
+     }
+}
+```
+### Params:
+
+| Name              | Type     |
+| :---------------- | :------- |
+| `slug` _required_ | `String` |
+
+### Response Body Type:
+
+| Name             | Type             |
+| :--------------- | :--------------- |
+| `article`        | `Object`         |
+| `title`          | `String`         |
+| `description`    | `String`         |
+| `body`           | `String`         |
+| `createdAt`      | `Date or String` |
+| `updatedAt`      | `Date or String` |
+| `favorited`      | `Boolean`        |
+| `favoritesCount` | `Number`         |
+| `Author`         | `Object`         |
+| `username`       | `String`         |
+| `bio`            | `String`         |
+| `image`          | `String`         |
+| `following`      | `Boolean`        |
+
+### Response Body Example:
+
+```JSON
+{
+    "article": {
+        "slug": "how-to-train-your-dragon",
+        "title": "How to train your dragon",
+        "description": "Ever wonder how?",
+        "body": "It takes a Jacobian",
+        "tagList": ["dragons", "training"],
+        "createdAt": "2016-02-18T03:22:56.637Z",
+        "updatedAt": "2016-02-18T03:48:35.824Z",
+        "favorited": false,
+        "favoritesCount": 0,
+        "author": {
+            "username": "jake",
+            "bio": "I work at statefarm",
+            "image": "https://i.stack.imgur.com/xHWG8.jpg",
+            "following": false
+        }
+    }
+}
+```
+
+
+### Errors:
+> #### `StatusCode` `400` - Invalid request body
+>
+> Must provide required params content listed above
+> #### `StatusCode` `404` - Invalid request body
+>
+> Slug provided in params does not exist
+> #### `StatusCode` `422` - Request body not unique
+>
+> Requested title is already taken
 
 ## Favorite Article
 

--- a/docs/articles.md
+++ b/docs/articles.md
@@ -251,6 +251,47 @@ At least one of: `title`, `description`, `body` must be provided
 > #### `StatusCode` `422` - Request body not unique
 >
 > Requested title is already taken
+> #### `StatusCode` `403` - Unauthorized
+>
+> This error will redirect user to homepage. 
+>
+> Authorization header not provided, Expired JWT token, Invalid JWT token
+
+## Delete Article
+
+### Endpoint: `DELETE` `/api/articles/:slug`
+
+### Authentication header required
+
+Authentication header Type:
+| Name | Type |
+|:-----|:-----|
+| `Authorization` | `String` |
+
+### Authentication header example:
+
+```JSON
+{
+  "Authorization": "Bearer jwt.token.here"
+}
+```
+
+### Params:
+
+| Name              | Type     |
+| :---------------- | :------- |
+| `slug` _required_ | `String` |
+
+
+### Errors:
+> #### `StatusCode` `400` - Invalid request body
+>
+> Must provide required params content listed above
+> #### `StatusCode` `403` - Unauthorized
+>
+> This error will redirect user to homepage. 
+>
+> Authorization header not provided, Expired JWT token, Invalid JWT token
 
 ## Favorite Article
 

--- a/src/controllers/articles.js
+++ b/src/controllers/articles.js
@@ -8,6 +8,7 @@ import {
   unFavoriteArticle,
   queryOneArticleAndUpdate,
   titleToSlug,
+  destroyArticle
 } from "../utils/articleControllerUtils";
 import { errorHandles } from "../utils/errorHandleUtils";
 
@@ -134,8 +135,24 @@ export async function handleUpdateArticle(req, res) {
 
     const payload = queryOneArticlePayloadFormat(updatedArticle);
 
-
     return res.status(200).json(payload);
+  } catch (e) {
+    console.error(e);
+
+    const error = errorHandles.find(({ message }) => message === e.message);
+
+    if (!error) return res.status(500).send("Server Error");
+
+    return res.status(error.statusCode).send(error.message);
+  }
+}
+export async function handleDeleteArticle(req, res) {
+  try {
+
+    await destroyArticle(req.user.email, req.params.slug)
+
+    return res.sendStatus(200)
+
   } catch (e) {
     console.error(e);
 

--- a/src/controllers/users.js
+++ b/src/controllers/users.js
@@ -1,4 +1,4 @@
-import { validateBody, validateEmail } from "../utils/validators";
+import { removeNull, validateBody, validateEmail } from "../utils/validators";
 import {
   createUser,
   updateUserInputFormat,
@@ -40,7 +40,6 @@ export async function registerUser(req, res) {
     return res.status(201).json(userPayload);
   } catch (e) {
     console.error(e);
-
 
     const error = errorHandles.find(({ message }) => message === e.message);
 
@@ -104,7 +103,13 @@ export async function updateUser(req, res) {
     if (!user) {
       throw new Error("No payload found");
     }
-    const formattedUser = updateUserInputFormat(user);
+    const formatPayload = {
+      username: user.username || null,
+      password: user.password || null,
+      bio: user.bio || null,
+      image: user.image || null,
+    };
+    const formattedUser = removeNull(formatPayload);
     if (!formattedUser) {
       throw new Error("Invalid payload format");
     }

--- a/src/routes/articles.js
+++ b/src/routes/articles.js
@@ -1,11 +1,12 @@
 import { Router } from "express";
 import { deserializeUser } from "../middleware/deserializeUser";
-import { handleCreateArticle, handleQueryOneArticle, handleFavoriteArticle, handleUnFavoriteArticle } from "../controllers/articles";
+import { handleCreateArticle, handleQueryOneArticle, handleFavoriteArticle, handleUnFavoriteArticle, handleUpdateArticle } from "../controllers/articles";
 
 const router = Router();
 
 router.post("/", deserializeUser, handleCreateArticle);
 router.get("/:slug", handleQueryOneArticle)
+router.put("/:slug",deserializeUser, handleUpdateArticle )
 router.post("/:slug/favorite", deserializeUser, handleFavoriteArticle)
 router.delete("/:slug/favorite", deserializeUser, handleUnFavoriteArticle)
 

--- a/src/routes/articles.js
+++ b/src/routes/articles.js
@@ -1,12 +1,13 @@
 import { Router } from "express";
 import { deserializeUser } from "../middleware/deserializeUser";
-import { handleCreateArticle, handleQueryOneArticle, handleFavoriteArticle, handleUnFavoriteArticle, handleUpdateArticle } from "../controllers/articles";
+import { handleCreateArticle, handleQueryOneArticle, handleFavoriteArticle, handleUnFavoriteArticle, handleUpdateArticle, handleDeleteArticle } from "../controllers/articles";
 
 const router = Router();
 
 router.post("/", deserializeUser, handleCreateArticle);
 router.get("/:slug", handleQueryOneArticle)
-router.put("/:slug",deserializeUser, handleUpdateArticle )
+router.put("/:slug", deserializeUser, handleUpdateArticle)
+router.delete("/:slug", deserializeUser, handleDeleteArticle)
 router.post("/:slug/favorite", deserializeUser, handleFavoriteArticle)
 router.delete("/:slug/favorite", deserializeUser, handleUnFavoriteArticle)
 

--- a/src/utils/articleControllerUtils.js
+++ b/src/utils/articleControllerUtils.js
@@ -222,3 +222,21 @@ export async function queryOneArticleAndUpdate({ email, slug, payload }) {
     return null;
   }
 }
+export async function destroyArticle(email, slug) {
+  try {
+    const destroy = await ArticleModel.destroy({
+      where: {
+        slug: slug,
+      },
+    });
+    if (destroy === 0) {
+      throw new Error("No rows destroyed");
+    }
+  } catch (e) {
+    if (e.name === "SequelizeUniqueConstraintError") {
+      throw new Error("Payload value(s) not unique");
+    } else {
+      throw e;
+    }
+  }
+}

--- a/src/utils/userControllerUtils.js
+++ b/src/utils/userControllerUtils.js
@@ -45,22 +45,6 @@ export async function queryOneUserAndUpdate(email, payload) {
   }
 }
 
-export function updateUserInputFormat(user) {
-  const removeNull = {
-    username: user.username || null,
-    password: user.password || null,
-    bio: user.bio || null,
-    image: user.image || null,
-  };
-  Object.keys(removeNull).forEach((key) => {
-    if (!removeNull[key]) {
-      delete removeNull[key];
-    }
-  });
-  if (Object.keys(removeNull).length === 0) return null;
-  return removeNull;
-}
-
 export function userPayloadFormat(payload) {
   return {
     user: {

--- a/src/utils/validators.js
+++ b/src/utils/validators.js
@@ -40,3 +40,12 @@ export function validateTagList(tags){
   return isValid
 }
 
+export function removeNull(payload) {
+  Object.keys(payload).forEach((key) => {
+    if (!payload[key]) {
+      delete payload[key];
+    }
+  });
+  if (Object.keys(payload).length === 0) return null;
+  return payload;
+}

--- a/test/end-to-end/articles.test.js
+++ b/test/end-to-end/articles.test.js
@@ -293,16 +293,18 @@ describe("test article route", () => {
           .mockReturnValueOnce(verifyTokenPayload);
 
         // end of middleware init
-        const modelInstanceMock = { ...queryArticleDbPayload.article, save: jest.fn(() => queryArticleDbPayload.article) }
+        const modelInstanceMock = {
+          ...queryArticleDbPayload.article,
+          save: jest.fn(() => queryArticleDbPayload.article),
+        };
 
         const queryOneArticleMock = jest
           .spyOn(articleControllerUtils, "queryOneArticle")
           .mockReturnValueOnce(modelInstanceMock);
 
-        const favoriteArticleMock = jest.spyOn(
-          articleControllerUtils,
-          "favoriteArticle"
-        ).mockReturnValueOnce(void 0)
+        const favoriteArticleMock = jest
+          .spyOn(articleControllerUtils, "favoriteArticle")
+          .mockReturnValueOnce(void 0);
 
         const { body, statusCode } = await supertest(app)
           .post("/api/articles/slug-slug-slug/favorite")
@@ -329,7 +331,7 @@ describe("test article route", () => {
           "new@new.new",
           "ID of Article"
         );
-        expect(modelInstanceMock.save).toHaveBeenCalled()
+        expect(modelInstanceMock.save).toHaveBeenCalled();
       });
     });
     describe("Given query does not exist and current user is authenticated", () => {
@@ -355,7 +357,7 @@ describe("test article route", () => {
         const favoriteArticleMock = jest.spyOn(
           articleControllerUtils,
           "favoriteArticle"
-        )
+        );
 
         const { statusCode } = await supertest(app)
           .post("/api/articles/slug-slug-slug/favorite")
@@ -405,7 +407,7 @@ describe("test article route", () => {
 
         const { statusCode } = await supertest(app)
           .post("/api/articles/slug-slug-slug/favorite")
-          .set("Authorization", `Bearer ${token}`)
+          .set("Authorization", `Bearer ${token}`);
 
         await deserializeUser(mockReq, mockRes, mockNext);
 
@@ -448,16 +450,18 @@ describe("test article route", () => {
           .mockReturnValueOnce(verifyTokenPayload);
 
         // end of middleware init
-        const modelInstanceMock = { ...queryArticleDbPayload.article, save: jest.fn(() => queryArticleDbPayload.article) }
+        const modelInstanceMock = {
+          ...queryArticleDbPayload.article,
+          save: jest.fn(() => queryArticleDbPayload.article),
+        };
 
         const queryOneArticleMock = jest
           .spyOn(articleControllerUtils, "queryOneArticle")
           .mockReturnValueOnce(modelInstanceMock);
 
-        const unFavoriteArticleMock = jest.spyOn(
-          articleControllerUtils,
-          "unFavoriteArticle"
-        ).mockReturnValueOnce(void 0)
+        const unFavoriteArticleMock = jest
+          .spyOn(articleControllerUtils, "unFavoriteArticle")
+          .mockReturnValueOnce(void 0);
 
         const { body, statusCode } = await supertest(app)
           .delete("/api/articles/slug-slug-slug/favorite")
@@ -484,7 +488,7 @@ describe("test article route", () => {
           "new@new.new",
           "ID of Article"
         );
-        expect(modelInstanceMock.save).toHaveBeenCalled()
+        expect(modelInstanceMock.save).toHaveBeenCalled();
       });
     });
     describe("Given query does not exist and current user is authenticated", () => {
@@ -510,7 +514,7 @@ describe("test article route", () => {
         const unFavoriteArticleMock = jest.spyOn(
           articleControllerUtils,
           "unFavoriteArticle"
-        )
+        );
 
         const { statusCode } = await supertest(app)
           .delete("/api/articles/slug-slug-slug/favorite")
@@ -560,7 +564,7 @@ describe("test article route", () => {
 
         const { statusCode } = await supertest(app)
           .delete("/api/articles/slug-slug-slug/favorite")
-          .set("Authorization", `Bearer ${token}`)
+          .set("Authorization", `Bearer ${token}`);
 
         await deserializeUser(mockReq, mockRes, mockNext);
 
@@ -581,6 +585,229 @@ describe("test article route", () => {
           verifyTokenPayload.email,
           "ARTICLE ID HERE"
         );
+      });
+    });
+  });
+
+  // PUT /api/articles/:slug
+  describe("PUT /api/articles/:slug - update article", () => {
+    describe("Given request payload is valid and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 201 and article payload", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const queryOneArticleAndUpdateMock = jest
+          .spyOn(articleControllerUtils, "queryOneArticleAndUpdate")
+          .mockReturnValueOnce(queryArticleDbPayload.article);
+
+        const { body, statusCode } = await supertest(app)
+          .put("/api/articles/old-title")
+          .set("Authorization", `Bearer ${token}`)
+          .send({ article: { title: "New Title" } });
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(200);
+
+        expect(body).toEqual(expectQueryArticlePayload);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleAndUpdateMock).toHaveBeenCalledWith({
+          email: verifyTokenPayload.email,
+          payload: expect.any(Object),
+          slug: expect.any(String),
+        });
+      });
+    });
+    describe("Given request payload is empty and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 400", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const queryOneArticleAndUpdateMock = jest
+          .spyOn(articleControllerUtils, "queryOneArticleAndUpdate")
+          .mockReturnValueOnce(queryArticleDbPayload);
+
+        const { statusCode } = await supertest(app)
+          .put("/api/articles/old-title")
+          .set("Authorization", `Bearer ${token}`);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(400);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleAndUpdateMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Given invalid payload format", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 400", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const queryOneArticleAndUpdateMock = jest.spyOn(
+          articleControllerUtils,
+          "queryOneArticleAndUpdate"
+        );
+
+        const { statusCode } = await supertest(app)
+          .put("/api/articles/old-title")
+          .set("Authorization", `Bearer ${token}`)
+          .send(invalidArticlePayloadFormat);
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(400);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleAndUpdateMock).not.toHaveBeenCalled();
+      });
+    });
+    describe("Given valid payload, but slug does not exist. User is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 404", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const queryOneArticleAndUpdateMock = jest
+          .spyOn(articleControllerUtils, "queryOneArticleAndUpdate")
+          .mockReturnValueOnce(null);
+
+        const { statusCode } = await supertest(app)
+          .put("/api/articles/not-existing-title")
+          .set("Authorization", `Bearer ${token}`)
+          .send({ article: { title: "New Title" } });
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(404);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleAndUpdateMock).toHaveBeenCalledWith({
+          email: verifyTokenPayload.email,
+          payload: expect.any(Object),
+          slug: expect.any(String),
+        });
+      });
+    });
+    describe("Given request payload is not unique, and current user is authenticated", () => {
+      let token = "";
+      beforeAll(() => (token = jwtUtils.signToken(dbPayload, "1m")));
+      it("should return status 422", async () => {
+        //middleware init
+        const mockReq = {
+          get: jest.fn(() => `Bearer ${token}`),
+        };
+        const mockRes = {};
+        const mockNext = jest.fn();
+
+        const verifyTokenMock = jest
+          .spyOn(jwtUtils, "verifyToken")
+          .mockReturnValueOnce(verifyTokenPayload);
+
+        // end of middleware init
+
+        const queryOneArticleAndUpdateMock = jest
+          .spyOn(articleControllerUtils, "queryOneArticleAndUpdate")
+          .mockRejectedValueOnce(new Error("Payload value(s) not unique"));
+
+        const { statusCode } = await supertest(app)
+          .put("/api/articles/old-title")
+          .set("Authorization", `Bearer ${token}`)
+          .send({ article: { title: "Old Title" } });
+
+        await deserializeUser(mockReq, mockRes, mockNext);
+
+        expect(statusCode).toBe(422);
+
+        // middleware tests
+        expect(mockReq.get).toHaveBeenCalledWith(`Authorization`);
+        expect(mockReq).toEqual({ ...mockReq, user: verifyTokenPayload });
+        expect(mockNext).toHaveBeenCalled();
+        //end of middleware tests
+
+        expect(verifyTokenMock).toBeCalledWith(expect.any(String));
+
+        expect(queryOneArticleAndUpdateMock).toHaveBeenCalledWith({
+          email: verifyTokenPayload.email,
+          payload: expect.any(Object),
+          slug: expect.any(String),
+        });
       });
     });
   });

--- a/test/integration/articleControllerUtils.test.js
+++ b/test/integration/articleControllerUtils.test.js
@@ -5,6 +5,7 @@ import {
 } from "../utils/articlesTestValue";
 import {
   createArticle,
+  destroyArticle,
   favoriteArticle,
   queryOneArticle,
   queryOneArticleAndUpdate,
@@ -150,6 +151,25 @@ describe("Integration tests for article controller utils", () => {
           });
         } catch (e) {
           expect(e.message).toEqual("Payload value(s) not unique");
+        }
+      });
+    });
+  });
+
+  describe("Test functionality of destroyArticle()", () => {
+    describe("Given valid user and slug exists", () => {
+      it("should remove article from database", async () => {
+        await expect(await destroyArticle(user.email, "new-new-new")).toBe(
+          undefined
+        ); // void function
+      });
+    });
+    describe("Given valid user and slug, but does not exist or belong to user", () => {
+      it("should throw error", async () => {
+        try {
+          await destroyArticle(user.email, "new-new-new")
+        } catch (e) {
+          expect(e.message).toEqual("No rows destroyed");
         }
       });
     });

--- a/test/integration/articleControllerUtils.test.js
+++ b/test/integration/articleControllerUtils.test.js
@@ -7,6 +7,7 @@ import {
   createArticle,
   favoriteArticle,
   queryOneArticle,
+  queryOneArticleAndUpdate,
   unFavoriteArticle,
 } from "../../src/utils/articleControllerUtils";
 import { createUser } from "../../src/utils/userControllerUtils";
@@ -123,6 +124,32 @@ describe("Integration tests for article controller utils", () => {
           await unFavoriteArticle(user.email, articleId.id);
         } catch (e) {
           expect(e.message).toEqual("No rows destroyed");
+        }
+      });
+    });
+  });
+
+  describe("Test functionality of queryOneArticleAndUpdate()", () => {
+    describe("Given valid user and slug, and update payload is unique", () => {
+      it("should update selected article and return the updated article", async () => {
+        const updatedArticle = await queryOneArticleAndUpdate({
+          email: user.email,
+          payload: { title: "New New New", slug: "new-new-new" },
+          slug: "click-bait-here",
+        });
+        expect(updatedArticle).toEqual({...expectQueryArticlePayload.article, id: expect.any(String)});
+      });
+    });
+    describe("Given valid user and slug, but update payload is not unique", () => {
+      it("should throw error", async () => {
+        try {
+          await queryOneArticleAndUpdate({
+            email: user.email,
+            payload: { title: "New New New", slug: "new-new-new" },
+            slug: "click-bait-here",
+          });
+        } catch (e) {
+          expect(e.message).toEqual("Payload value(s) not unique");
         }
       });
     });

--- a/test/unit/reqBodyVerification.test.js
+++ b/test/unit/reqBodyVerification.test.js
@@ -1,4 +1,4 @@
-import { validateBody } from "../../src/utils/validators";
+import { validateBody, removeNull } from "../../src/utils/validators";
 
 const expectedVal = {
   1: "string",
@@ -12,9 +12,9 @@ describe("Unit test functionality of validateBody()", () => {
       it("should return false", () => {
         const input = { food: "borger" };
 
-        const valid = validateBody(input,expectedVal) 
+        const valid = validateBody(input, expectedVal);
 
-        expect(valid).toBe(false)
+        expect(valid).toBe(false);
       });
     });
     describe("Types doesn't match - case 1", () => {
@@ -25,9 +25,9 @@ describe("Unit test functionality of validateBody()", () => {
           3: "food",
         };
 
-        const valid = validateBody(input,expectedVal) 
+        const valid = validateBody(input, expectedVal);
 
-        expect(valid).toBe(false)
+        expect(valid).toBe(false);
       });
     });
     describe("Types doesn't match - case 2", () => {
@@ -38,23 +38,68 @@ describe("Unit test functionality of validateBody()", () => {
           3: null,
         };
 
-        const valid = validateBody(input,expectedVal) 
+        const valid = validateBody(input, expectedVal);
 
-        expect(valid).toBe(false)
+        expect(valid).toBe(false);
       });
     });
   });
   describe("Valid inputs", () => {
     it("should return true", () => {
-      const  input = {
+      const input = {
         1: "keyboard",
         2: 1.46,
-        3: null
-      }
+        3: null,
+      };
 
-      const valid = validateBody(input, expectedVal)
+      const valid = validateBody(input, expectedVal);
 
-      expect(valid).toBe(true)
-    })
-  })
+      expect(valid).toBe(true);
+    });
+  });
+});
+describe("Unit test of removeNull()", () => {
+  describe("Given keys all null", () => {
+    it("should return null", () => {
+      const testValues = {
+        something: null,
+        test: null,
+        food: null,
+      };
+      const test = removeNull(testValues);
+
+      expect(test).toEqual(null);
+    });
+  });
+  describe("Given keys has value", () => {
+    it("should only return propeties with values", () => {
+      const update = {
+        email: null,
+        username: "something",
+        password: null,
+        bio: "cool",
+        image: null,
+      };
+      const test = removeNull(update);
+
+      expect(test).toEqual({
+        username: update.username,
+        bio: update.bio,
+      });
+    });
+  });
+  describe("Given key properties with at least 1 key not valued null", () => {
+    it("should return at least key value pair", () => {
+      const update = {
+        email: null,
+        username: null,
+        password: null,
+        bio: "to test or not to test",
+        image: null,
+      };
+      const test = removeNull(update);
+
+      expect(test).toEqual({ bio: update.bio });
+    });
+  });
 });

--- a/test/unit/userControllerUtils.test.js
+++ b/test/unit/userControllerUtils.test.js
@@ -1,5 +1,5 @@
-import { userPayloadFormat, getToken, updateUserInputFormat } from "../../src/utils/userControllerUtils";
-import { dbPayload, invalidCreateUserInput, userPayload } from "../utils/testValues";
+import { userPayloadFormat, getToken  } from "../../src/utils/userControllerUtils";
+import { dbPayload,  userPayload } from "../utils/testValues";
 
 describe("Unit test of userPayloadFormat()", () => {
   describe("Given database object and token to format", () => {
@@ -17,43 +17,6 @@ describe("Unit test of getToken()", () => {
       const test = getToken("Bearer token");
 
       expect(test).toEqual("token");
-    });
-  });
-  describe("Unit test of updateUserInputFormat()", () => {
-    describe("Given keys not related to user properties", () => {
-      it("should return null", () => {
-        const test = updateUserInputFormat(invalidCreateUserInput);
-
-        expect(test).toEqual(null);
-      });
-    });
-    describe("Given keys related to user properties and all values are null", () => {
-      it("should return null", () => {
-        const update = {
-          email: null,
-          username: null,
-          password: null,
-          bio: null,
-          image: null
-        }
-        const test = updateUserInputFormat(update);
-
-        expect(test).toEqual(null);
-      });
-    });
-    describe("Given keys related to user properties with at least 1 key not valued null", () => {
-      it("should return null", () => {
-        const update = {
-          email: null,
-          username: null,
-          password: null,
-          bio: "to test or not to test",
-          image: null
-        }
-        const test = updateUserInputFormat(update);
-
-        expect(test).toEqual({ bio: update.bio });
-      });
     });
   });
 });


### PR DESCRIPTION
# Summary
In this PR I created a route that would delete an article entry in the database. The route is very simple, it uses the authentication middleware to grab the current user data. The controller would grab the slug from the params and would query the database for the user that owns the article with the matching slug, if the slug exists and matches the user is the owner of the article, then would be removed from the article table row in the database. 
# Screenshot of the tests
![Screenshot 2022-10-26 at 5 58 50 PM](https://user-images.githubusercontent.com/60503218/198149138-e0b384cd-26ac-4682-adee-126e70858988.png)
![Screenshot 2022-10-26 at 5 59 08 PM](https://user-images.githubusercontent.com/60503218/198149151-8583db2f-c4f8-4721-a5ea-65dd9d90703b.png)
